### PR TITLE
Fix mining issue with incorrect reward.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,8 @@ set(PROJECT_VENDOR_URL "https://qwertycoin.org")
 set(PROJECT_VENDOR_DOMAIN_REVERSED "org.qwertycoin")
 project(${PROJECT_NAME} VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 
-if(APPLE OR FREEBSD)
-    # Compile src/Platform/OSX/System/asm.s file.
+if(UNIX)
+    # Compile src/Platform/OSX/System/asm.s and breakpad_getcontext.S files.
     enable_language(ASM)
 endif()
 

--- a/cmake/external/Breakpad.cmake
+++ b/cmake/external/Breakpad.cmake
@@ -55,6 +55,7 @@ if(UNIX AND NOT APPLE AND NOT ANDROID)
         "${breakpad_SOURCE_DIR}/src/common/linux/linux_libc_support.cc"
         "${breakpad_SOURCE_DIR}/src/common/linux/memory_mapped_file.cc"
         "${breakpad_SOURCE_DIR}/src/common/linux/safe_readlink.cc"
+        "${breakpad_SOURCE_DIR}/src/common/linux/breakpad_getcontext.S"
     )
 
     set(LINUX_SYSCALL_SUPPORT_HEADER_IN "${linuxsyscallsupport_SOURCE_DIR}/linux_syscall_support.h")

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -730,6 +730,14 @@ bool core::get_block_template(
         return false;
     }
 
+    uint32_t previousBlockHeight = 0;
+    uint64_t blockTarget = CryptoNote::parameters::DIFFICULTY_TARGET;
+
+    if (height >= CryptoNote::parameters::UPGRADE_HEIGHT_REWARD_SCHEME) {
+        getBlockHeight(b.previousBlockHash, previousBlockHeight);
+        blockTarget = b.timestamp - getBlockTimestamp(previousBlockHeight);
+    }
+
     // two-phase miner transaction generation: we don't know exact block size until we prepare
     // block, but we don't know reward until we know block size, so first miner transaction
     // generated with fake amount of money, and with phase we know think we know expected block size
@@ -745,7 +753,8 @@ bool core::get_block_template(
         adr,
         b.baseTransaction,
         ex_nonce,
-        14
+        14,
+        blockTarget
     );
     if (!r) {
         logger(ERROR, BRIGHT_RED) << "Failed to construct miner tx, first chance";
@@ -764,7 +773,8 @@ bool core::get_block_template(
             adr,
             b.baseTransaction,
             ex_nonce,
-            14
+            14,
+            blockTarget
         );
 
         if (!(r)) {

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -735,6 +735,9 @@ bool core::get_block_template(
 
     if (height >= CryptoNote::parameters::UPGRADE_HEIGHT_REWARD_SCHEME) {
         getBlockHeight(b.previousBlockHash, previousBlockHeight);
+        uint64_t prev_timestamp = getBlockTimestamp(previousBlockHeight);
+        if(prev_timestamp >= b.timestamp)
+            return false;
         blockTarget = b.timestamp - getBlockTimestamp(previousBlockHeight);
     }
 

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -269,9 +269,9 @@ bool Currency::constructMinerTx(
     Transaction &tx,
     const BinaryArray &extraNonce /* = BinaryArray()*/,
     size_t maxOuts /* = 1*/,
-    uint64_t blockTarget /* = 0*/) const
+    uint64_t blockTarget /* = 0xffffffffffffffff*/) const
 {
-    if (blockTarget == 0)
+    if (blockTarget == 0xffffffffffffffff)
         blockTarget = difficultyTarget();
     tx.inputs.clear();
     tx.outputs.clear();

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -268,8 +268,11 @@ bool Currency::constructMinerTx(
     const AccountPublicAddress &minerAddress,
     Transaction &tx,
     const BinaryArray &extraNonce /* = BinaryArray()*/,
-    size_t maxOuts /* = 1*/) const
+    size_t maxOuts /* = 1*/,
+    uint64_t blockTarget /* = 0*/) const
 {
+    if (blockTarget == 0)
+        blockTarget = difficultyTarget();
     tx.inputs.clear();
     tx.outputs.clear();
     tx.extra.clear();
@@ -300,7 +303,7 @@ bool Currency::constructMinerTx(
             blockReward,
             emissionChange,
             height,
-            difficultyTarget())
+            blockTarget)
         ) {
         logger(INFO) << "Block is too big";
         return false;

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -181,7 +181,7 @@ public:
         Transaction &tx,
         const BinaryArray &extraNonce = BinaryArray(),
         size_t maxOuts = 1,
-        uint64_t blockTarget = 0) const;
+        uint64_t blockTarget = 0xffffffffffffffff) const;
 
     bool isFusionTransaction(const Transaction& transaction, uint32_t height) const;
     bool isFusionTransaction(const Transaction& transaction, size_t size, uint32_t height) const;

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -180,7 +180,8 @@ public:
         const AccountPublicAddress &minerAddress,
         Transaction &tx,
         const BinaryArray &extraNonce = BinaryArray(),
-        size_t maxOuts = 1) const;
+        size_t maxOuts = 1,
+        uint64_t blockTarget = 0) const;
 
     bool isFusionTransaction(const Transaction& transaction, uint32_t height) const;
     bool isFusionTransaction(const Transaction& transaction, size_t size, uint32_t height) const;


### PR DESCRIPTION
Miners use default block target to calculate block reward while verification code use calculated target value to verify this block,  this is the reason of the error during the mining. This pull requests fixes reward calculation for block generation.

Also I have added the Linux build fix in this PR,  tell me if it is wrong,  I'll add it in separate pull request.