### PR TITLE
New difficulty adjustment algorithm

### DIFF
--- a/lib/Common/Math.h
+++ b/lib/Common/Math.h
@@ -19,9 +19,35 @@
 #pragma once
 
 #include <algorithm>
+#include <numeric>
 #include <vector>
 
 namespace Common {
+
+template <class T>
+T meanValue(const std::vector<T>& v)
+{
+    if (v.empty()) {
+        return T();
+    }
+
+    T sum = std::accumulate(v.begin(), v.end(), T());
+    return sum / v.size();
+}
+
+template <class T>
+T stddevValue(const std::vector<T>& v)
+{
+    if (v.size() < 2) {
+        return T();
+    }
+
+    T mean = meanValue(v);
+    std::vector<T> diff(v.size());
+    std::transform(v.begin(), v.end(), diff.begin(), [mean](T x) { return x - mean; });
+    T sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), T());
+    return std::sqrt(sq_sum / v.size());
+}
 
 template <class T>
 T medianValue(std::vector<T> &v)

--- a/lib/CryptoNoteCore/Blockchain.cpp
+++ b/lib/CryptoNoteCore/Blockchain.cpp
@@ -851,9 +851,12 @@ difficulty_type Blockchain::getDifficultyForNextBlock(uint64_t block_time)
 
 bool Blockchain::getDifficultyStat(uint32_t height, IMinerHandler::stat_period period, uint32_t& block_num, uint64_t& avg_solve_time, uint64_t& stddev_solve_time, uint32_t& outliers_num)
 {
-    uint32_t min_height = CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24;
+    uint32_t min_height = CryptoNote::parameters::UPGRADE_HEIGHT_V6 +
+            CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24;
     if (height < min_height) {
-        logger (WARNING) << "Can't get difficulty stat for height less than " << CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24;
+        logger (WARNING) << "Can't get difficulty stat for height less than " <<
+                            CryptoNote::parameters::UPGRADE_HEIGHT_V6 +
+                            CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24;
         return false;
     }
     uint64_t time_window = 0;
@@ -876,7 +879,7 @@ bool Blockchain::getDifficultyStat(uint32_t height, IMinerHandler::stat_period p
     }
     std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
     if (height >= m_blocks.size()) {
-        logger (ERROR) << "Invalid height " << height << ", " << m_blocks.size() << "blocks available";
+        logger (ERROR) << "Invalid height " << height << ", " << m_blocks.size() << " blocks available";
         throw std::runtime_error("Invalid height");
     }
     uint64_t stop_time = m_blocks[height].bl.timestamp - time_window;
@@ -886,6 +889,7 @@ bool Blockchain::getDifficultyStat(uint32_t height, IMinerHandler::stat_period p
         solve_times.push_back(m_blocks[height].bl.timestamp - m_blocks[height - 1].bl.timestamp);
         height--;
     }
+    logger (INFO) << "min height: " << height;
     block_num = solve_times.size();
     avg_solve_time = Common::meanValue(solve_times);
     stddev_solve_time = Common::stddevValue(solve_times);

--- a/lib/CryptoNoteCore/Blockchain.cpp
+++ b/lib/CryptoNoteCore/Blockchain.cpp
@@ -622,7 +622,7 @@ bool Blockchain::init(const std::string &config_folder, bool load_existing)
     logger(INFO, BRIGHT_GREEN)
         << "Blockchain initialized. last block: " << m_blocks.size() - 1 << ", "
         << Common::timeIntervalToString(timestamp_diff)
-        << " time ago, current difficulty: " << getDifficultyForNextBlock(time(nullptr));
+        << " time ago, current difficulty: " << getDifficultyForNextBlock();
 
     return true;
 }
@@ -821,7 +821,7 @@ bool Blockchain::getBlockHeight(const Crypto::Hash &blockId, uint32_t &blockHeig
     return m_blockIndex.getBlockHeight(blockId, blockHeight);
 }
 
-difficulty_type Blockchain::getDifficultyForNextBlock(uint64_t block_time)
+difficulty_type Blockchain::getDifficultyForNextBlock()
 {
     std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
     std::vector<uint64_t> timestamps;
@@ -844,8 +844,7 @@ difficulty_type Blockchain::getDifficultyForNextBlock(uint64_t block_time)
         static_cast<uint32_t>(m_blocks.size()),
         BlockMajorVersion,
         timestamps,
-        cumulative_difficulties,
-        block_time
+        cumulative_difficulties
                 );
 }
 
@@ -1303,7 +1302,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(
         }
     }
 
-    return m_currency.nextDifficulty(static_cast<uint32_t>(m_blocks.size()), BlockMajorVersion, timestamps, cumulative_difficulties, time(nullptr));
+    return m_currency.nextDifficulty(static_cast<uint32_t>(m_blocks.size()), BlockMajorVersion, timestamps, cumulative_difficulties);
 }
 
 bool Blockchain::prevalidate_miner_transaction(const Block &b, uint32_t height)
@@ -2651,8 +2650,7 @@ bool Blockchain::pushBlock(
     }
 
     auto targetTimeStart = std::chrono::steady_clock::now();
-    difficulty_type currentDifficulty = getDifficultyForNextBlock(blockData.timestamp);
-    logger (INFO) << "currentDifficulty: " << currentDifficulty;
+    difficulty_type currentDifficulty = getDifficultyForNextBlock();
     auto target_calculating_time = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - targetTimeStart
     ).count();

--- a/lib/CryptoNoteCore/Blockchain.h
+++ b/lib/CryptoNoteCore/Blockchain.h
@@ -31,6 +31,7 @@
 #include <CryptoNoteCore/CryptoNoteFormatUtils.h>
 #include <CryptoNoteCore/Currency.h>
 #include <CryptoNoteCore/IBlockchainStorageObserver.h>
+#include <CryptoNoteCore/IMinerHandler.h>
 #include <CryptoNoteCore/IntrusiveLinkedList.h>
 #include <CryptoNoteCore/ITransactionValidator.h>
 #include <CryptoNoteCore/MessageQueue.h>
@@ -93,6 +94,7 @@ public:
     Crypto::Hash getTailId();
     Crypto::Hash getTailId(uint32_t &height);
     difficulty_type getDifficultyForNextBlock(uint64_t block_time);
+    bool getDifficultyStat(uint32_t height, IMinerHandler::stat_period period, uint32_t& block_num, uint64_t& avg_solve_time, uint64_t& stddev_solve_time, uint32_t& outliers_num);
     uint64_t getBlockTimestamp(uint32_t height);
     uint64_t getMinimalFee(uint32_t height);
     uint64_t getCoinsInCirculation();

--- a/lib/CryptoNoteCore/Blockchain.h
+++ b/lib/CryptoNoteCore/Blockchain.h
@@ -93,7 +93,7 @@ public:
     uint32_t getCurrentBlockchainHeight(); // TODO: rename to getCurrentBlockchainSize
     Crypto::Hash getTailId();
     Crypto::Hash getTailId(uint32_t &height);
-    difficulty_type getDifficultyForNextBlock(uint64_t block_time);
+    difficulty_type getDifficultyForNextBlock();
     bool getDifficultyStat(uint32_t height, IMinerHandler::stat_period period, uint32_t& block_num, uint64_t& avg_solve_time, uint64_t& stddev_solve_time, uint32_t& outliers_num);
     uint64_t getBlockTimestamp(uint32_t height);
     uint64_t getMinimalFee(uint32_t height);

--- a/lib/CryptoNoteCore/Blockchain.h
+++ b/lib/CryptoNoteCore/Blockchain.h
@@ -92,7 +92,7 @@ public:
     uint32_t getCurrentBlockchainHeight(); // TODO: rename to getCurrentBlockchainSize
     Crypto::Hash getTailId();
     Crypto::Hash getTailId(uint32_t &height);
-    difficulty_type getDifficultyForNextBlock();
+    difficulty_type getDifficultyForNextBlock(uint64_t block_time);
     uint64_t getBlockTimestamp(uint32_t height);
     uint64_t getMinimalFee(uint32_t height);
     uint64_t getCoinsInCirculation();

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -708,7 +708,7 @@ bool core::get_block_template(
             }
         }
 
-        diffic = m_blockchain.getDifficultyForNextBlock(b.timestamp);
+        diffic = m_blockchain.getDifficultyForNextBlock();
         if (!(diffic)) {
             logger(ERROR, BRIGHT_RED) << "difficulty overhead.";
             return false;
@@ -1694,9 +1694,9 @@ std::error_code core::executeLocked(const std::function<std::error_code()> &func
     return func();
 }
 
-uint64_t core::getNextBlockDifficulty(uint64_t block_time)
+uint64_t core::getNextBlockDifficulty()
 {
-    return m_blockchain.getDifficultyForNextBlock(block_time);
+    return m_blockchain.getDifficultyForNextBlock();
 }
 
 uint64_t core::getTotalGeneratedAmount()

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -641,11 +641,6 @@ bool core::get_block_template(
     {
         LockedBlockchainStorage blockchainLock(m_blockchain);
         height = m_blockchain.getCurrentBlockchainHeight();
-        diffic = m_blockchain.getDifficultyForNextBlock();
-        if (!(diffic)) {
-            logger(ERROR, BRIGHT_RED) << "difficulty overhead.";
-            return false;
-        }
 
         b = boost::value_initialized<Block>();
         b.majorVersion = m_blockchain.getBlockMajorVersionForHeight(height);
@@ -711,6 +706,12 @@ bool core::get_block_template(
             if (b.timestamp < median_ts) {
                 b.timestamp = median_ts;
             }
+        }
+
+        diffic = m_blockchain.getDifficultyForNextBlock(b.timestamp);
+        if (!(diffic)) {
+            logger(ERROR, BRIGHT_RED) << "difficulty overhead.";
+            return false;
         }
 
         median_size = m_blockchain.getCurrentCumulativeBlocksizeLimit() / 2;
@@ -1684,9 +1685,9 @@ std::error_code core::executeLocked(const std::function<std::error_code()> &func
     return func();
 }
 
-uint64_t core::getNextBlockDifficulty()
+uint64_t core::getNextBlockDifficulty(uint64_t block_time)
 {
-    return m_blockchain.getDifficultyForNextBlock();
+    return m_blockchain.getDifficultyForNextBlock(block_time);
 }
 
 uint64_t core::getTotalGeneratedAmount()

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -843,6 +843,11 @@ bool core::get_block_template(
     return false;
 }
 
+bool core::get_difficulty_stat(uint32_t height, IMinerHandler::stat_period period, uint32_t &block_num, uint64_t &avg_solve_time, uint64_t &stddev_solve_time, uint32_t &outliers_num)
+{
+    return m_blockchain.getDifficultyStat(height, period, block_num, avg_solve_time, stddev_solve_time, outliers_num);
+}
+
 std::vector<Crypto::Hash> core::findBlockchainSupplement(
     const std::vector<Crypto::Hash> &remoteBlockIds,
     size_t maxCount,

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -728,6 +728,7 @@ bool core::get_block_template(
             txs_size,
             fee)
         ) {
+        logger(ERROR, BRIGHT_RED) << "failed to fill block template from mempool.";
         return false;
     }
 
@@ -737,8 +738,11 @@ bool core::get_block_template(
     if (height >= CryptoNote::parameters::UPGRADE_HEIGHT_REWARD_SCHEME) {
         getBlockHeight(b.previousBlockHash, previousBlockHeight);
         uint64_t prev_timestamp = getBlockTimestamp(previousBlockHeight);
-        if(prev_timestamp >= b.timestamp)
+        if(prev_timestamp >= b.timestamp) {
+            logger(ERROR, BRIGHT_RED) << "incorrect timestamp, prev = "
+               << prev_timestamp << ",  new = " << b.timestamp;
             return false;
+        }
         blockTarget = b.timestamp - getBlockTimestamp(previousBlockHeight);
     }
 

--- a/lib/CryptoNoteCore/Core.h
+++ b/lib/CryptoNoteCore/Core.h
@@ -79,6 +79,13 @@ public:
         difficulty_type &diffic,
         uint32_t &height,
         const BinaryArray &ex_nonce) override;
+    bool get_difficulty_stat(
+        uint32_t height,
+        stat_period period,
+        uint32_t& block_num,
+        uint64_t& avg_solve_time,
+        uint64_t& stddev_solve_time,
+        uint32_t& outliers_num) override;
 
     bool addObserver(ICoreObserver *observer) override;
     bool removeObserver(ICoreObserver *observer) override;

--- a/lib/CryptoNoteCore/Core.h
+++ b/lib/CryptoNoteCore/Core.h
@@ -284,7 +284,7 @@ public:
 
     void rollbackBlockchain(uint32_t height) override;
 
-    uint64_t getNextBlockDifficulty(uint64_t block_time);
+    uint64_t getNextBlockDifficulty();
     uint64_t getTotalGeneratedAmount();
     uint8_t getBlockMajorVersionForHeight(uint32_t height) const;
     bool f_getMixin(const Transaction &transaction, uint64_t &mixin);

--- a/lib/CryptoNoteCore/Core.h
+++ b/lib/CryptoNoteCore/Core.h
@@ -277,7 +277,7 @@ public:
 
     void rollbackBlockchain(uint32_t height) override;
 
-    uint64_t getNextBlockDifficulty();
+    uint64_t getNextBlockDifficulty(uint64_t block_time);
     uint64_t getTotalGeneratedAmount();
     uint8_t getBlockMajorVersionForHeight(uint32_t height) const;
     bool f_getMixin(const Transaction &transaction, uint64_t &mixin);

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -678,16 +678,13 @@ uint64_t Currency::roundUpMinFee(uint64_t minimalFee, int digits) const
     return ret;
 }
 
-difficulty_type Currency::nextDifficulty(
-    uint32_t height,
+difficulty_type Currency::nextDifficulty(uint32_t height,
     uint8_t blockMajorVersion,
     std::vector<uint64_t> timestamps,
-    std::vector<difficulty_type> cumulativeDifficulties,
-    uint64_t block_time) const
+    std::vector<difficulty_type> cumulativeDifficulties) const
 {
-    logger (INFO) << "Currency::nextDifficulty(" << height << ", " << (uint32_t)blockMajorVersion << ")";
     if (blockMajorVersion >= BLOCK_MAJOR_VERSION_6) {
-        return nextDifficultyV6(blockMajorVersion, timestamps, cumulativeDifficulties, block_time, height);
+        return nextDifficultyV6(blockMajorVersion, timestamps, cumulativeDifficulties, height);
     } else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_5) {
         return nextDifficultyV5(blockMajorVersion, timestamps, cumulativeDifficulties);
     } else if (blockMajorVersion == BLOCK_MAJOR_VERSION_3
@@ -940,7 +937,7 @@ difficulty_type Currency::nextDifficultyV5(
 difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     std::vector<uint64_t> timestamps,
     std::vector<difficulty_type> cumulativeDifficulties,
-    uint64_t block_time, uint32_t height) const
+    uint32_t height) const
 {
     if(isTestnet()){
         return CryptoNote::parameters::DEFAULT_DIFFICULTY;

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -969,7 +969,7 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     }
 
     // check all values in input vectors greater than previous value to calc adjacent differences later
-    if (std::adjacent_find(timestamps.begin(), timestamps.end(), std::greater_equal<uint64_t>()) != timestamps.end()) {
+    if (std::adjacent_find(timestamps.begin(), timestamps.end(), std::greater<uint64_t>()) != timestamps.end()) {
         logger (ERROR) << "Invalid timestamps for difficulty calculation";
         return nextDiffV6;
     }

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -1037,10 +1037,11 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
         nextDiffV6 = real_last_difficulty *
                 std::min(1.2, double(difficulty_target) / double(real_avg_solveTime));
     } else if (real_avg_solveTime > difficulty_target) {
-        nextDiffV6 = std::max(CryptoNote::parameters::DEFAULT_DIFFICULTY,
-                              difficulty_type(real_last_difficulty * double(difficulty_target) / double(real_avg_solveTime)));
+        nextDiffV6 = std::max<difficulty_type>(CryptoNote::parameters::DEFAULT_DIFFICULTY,
+                              real_last_difficulty * double(difficulty_target) / double(real_avg_solveTime));
     } else {
-        nextDiffV6 = std::max(CryptoNote::parameters::DEFAULT_DIFFICULTY, real_last_difficulty);
+        nextDiffV6 = std::max<difficulty_type>(CryptoNote::parameters::DEFAULT_DIFFICULTY,
+                                               real_last_difficulty);
     }
     return nextDiffV6;
 }

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -939,6 +939,9 @@ difficulty_type Currency::nextDifficultyV6(
     std::vector<difficulty_type> cumulativeDifficulties,
     uint64_t block_time) const
 {
+    if(isTestnet()){
+        return 10000;
+    }
     // LWMA-2 difficulty algorithm
     // Copyright (c) 2017-2018 Zawy, MIT License
     // https://github.com/zawy12/difficulty-algorithms/issues/3
@@ -983,14 +986,8 @@ difficulty_type Currency::nextDifficultyV6(
         nextDiffV6 = (prev_D * 110ull) / 100ull;
     }
 
-    // minimum limit
-    if (nextDiffV6 < 1000) {
-        nextDiffV6 = 1000;
-    }
-    if(isTestnet()){
-        nextDiffV6 = 10000;
-    }
-
+    if(T > 3 * m_difficultyTarget)
+        nextDiffV6 *= 1.0 / log(double(T) / double(m_difficultyTarget));
     return nextDiffV6;
 }
 

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -947,6 +947,14 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     // Dynamic difficulty calculation window
     uint32_t diffWindow = timestamps.size();
 
+    // check if we use special scenario with some fixed diff
+    if (CryptoNote::parameters::FIXED_DIFFICULTY > 0)
+    {
+        logger (WARNING) << "Fixed difficulty is used: " <<
+                            CryptoNote::parameters::FIXED_DIFFICULTY;
+        return CryptoNote::parameters::FIXED_DIFFICULTY;
+    }
+
     difficulty_type nextDiffV6 = CryptoNote::parameters::DEFAULT_DIFFICULTY;
     // Condition #1 When starting a chain or a working testnet requiring
     // block sample gathering until enough blocks are available (Kick-off Scenario)

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -963,8 +963,7 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     // Consider this as a service or trial period.
     // With EPoW reward algo in place, we don't really need to worry about attackers
     // or large miners taking advanatage of our system.
-    if (height < CryptoNote::parameters::UPGRADE_HEIGHT_V6 +
-            CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24) {
+    if (height < CryptoNote::parameters::UPGRADE_HEIGHT_V6 + diffWindow) {
         return nextDiffV6;
     }
 

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -964,7 +964,7 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     // Consider this as a service or trial period.
     // With EPoW reward algo in place, we don't really need to worry about attackers
     // or large miners taking advanatage of our system.
-    if (height < (720 + diffWindow)) {
+    if (height < CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24) {
         return nextDiffV6;
     }
 

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -1000,18 +1000,9 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
     uint64_t difficulty_target = CryptoNote::parameters::DIFFICULTY_TARGET;
 
     // check if last solve time is outlier
-    uint64_t last_solvetime = solveTimes.back();
     uint64_t low_solvetime_limit = 0;
     if (avg_solvetime > stddev_solvetime)
         low_solvetime_limit = avg_solvetime - stddev_solvetime;
-    if((low_solvetime_limit <= last_solvetime) &&
-       (last_solvetime <= avg_solvetime + stddev_solvetime))
-    {
-        // Use static scenario, network hashrate looks stable
-        nextDiffV6 = difficulties.back();
-        return nextDiffV6;
-    }
-
     // combine times and difficulties in one container
     std::vector<std::pair<uint64_t, difficulty_type>> combined;
     combined.resize(solveTimes.size());
@@ -1047,11 +1038,12 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
 
     if (real_avg_solveTime < difficulty_target) {
         nextDiffV6 = real_last_difficulty *
-                std::min(1.5, double(difficulty_target) / double(difficulty_target - real_avg_solveTime));
+                std::min(1.2, double(difficulty_target) / double(real_avg_solveTime));
     } else if (real_avg_solveTime > difficulty_target) {
-        nextDiffV6 = real_last_difficulty * (1.0 - double(real_avg_solveTime - difficulty_target) / double(real_avg_solveTime));
+        nextDiffV6 = std::max(CryptoNote::parameters::DEFAULT_DIFFICULTY,
+                              difficulty_type(real_last_difficulty * double(difficulty_target) / double(real_avg_solveTime)));
     } else {
-        nextDiffV6 = real_last_difficulty;
+        nextDiffV6 = std::max(CryptoNote::parameters::DEFAULT_DIFFICULTY, real_last_difficulty);
     }
     return nextDiffV6;
 }

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -909,10 +909,12 @@ difficulty_type Currency::nextDifficultyV5(
         }
     }
 
+    // It is a potential error,  N should be less than cumulativeDifficulties.size()
     nextDiffV5 = uint64_t((cumulativeDifficulties[N] - cumulativeDifficulties[0]) * T * (N + 1))
                  / uint64_t(2 * L);
     nextDiffV5 = (nextDiffV5 * 99ull) / 100ull;
 
+    // It is a potential error,  N should be less than cumulativeDifficulties.size()
     prev_D = cumulativeDifficulties[N] - cumulativeDifficulties[N - 1];
     nextDiffV5 = clamp(
         (uint64_t)(prev_D * 67ull / 100ull),

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -684,7 +684,9 @@ difficulty_type Currency::nextDifficulty(
     uint64_t block_time) const
 {
     logger (INFO) << "Currency::nextDifficulty(" << height << ", " << (uint32_t)blockMajorVersion << ")";
-    if (blockMajorVersion >= BLOCK_MAJOR_VERSION_5) {
+    if (blockMajorVersion >= BLOCK_MAJOR_VERSION_6) {
+        return nextDifficultyV6(blockMajorVersion, timestamps, cumulativeDifficulties, block_time);
+    } else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_5) {
         return nextDifficultyV5(blockMajorVersion, timestamps, cumulativeDifficulties);
     } else if (blockMajorVersion == BLOCK_MAJOR_VERSION_3
                || blockMajorVersion == BLOCK_MAJOR_VERSION_4) {
@@ -934,7 +936,8 @@ difficulty_type Currency::nextDifficultyV5(
 difficulty_type Currency::nextDifficultyV6(
     uint8_t blockMajorVersion,
     std::vector<std::uint64_t> timestamps,
-    std::vector<difficulty_type> cumulativeDifficulties) const
+    std::vector<difficulty_type> cumulativeDifficulties,
+    uint64_t block_time) const
 {
     // LWMA-2 difficulty algorithm
     // Copyright (c) 2017-2018 Zawy, MIT License
@@ -942,7 +945,7 @@ difficulty_type Currency::nextDifficultyV6(
     // with modifications by Ryo Currency developers
     // courtesy to aivve from Karbo
 
-    const int64_t  T = static_cast<int64_t>(m_difficultyTarget);
+    const int64_t  T = static_cast<int64_t>(block_time - timestamps.back());
     int64_t  N = difficultyBlocksCount3();
     int64_t  L(0), ST, sum_3_ST(0);
     uint64_t nextDiffV6, prev_D;

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -213,7 +213,7 @@ public:
     difficulty_type nextDifficulty(uint32_t height,
         uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
-        std::vector<difficulty_type> Difficulties, uint64_t block_time) const;
+        std::vector<difficulty_type> Difficulties) const;
     difficulty_type nextDifficultyV1(
         std::vector<uint64_t> timestamps,
         std::vector<difficulty_type> Difficulties) const;
@@ -229,7 +229,7 @@ public:
         std::vector<difficulty_type> Difficulties) const;
     difficulty_type nextDifficultyV6(uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
-        std::vector<difficulty_type> Difficulties, uint64_t block_time,
+        std::vector<difficulty_type> Difficulties,
         uint32_t height) const;
 
     bool checkProofOfWorkV1(

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -229,7 +229,8 @@ public:
         std::vector<difficulty_type> Difficulties) const;
     difficulty_type nextDifficultyV6(uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
-        std::vector<difficulty_type> Difficulties, uint64_t block_time) const;
+        std::vector<difficulty_type> Difficulties, uint64_t block_time,
+        uint32_t height) const;
 
     bool checkProofOfWorkV1(
         Crypto::cn_context &context,

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -100,7 +100,9 @@ public:
     size_t difficultyCut() const { return m_difficultyCut; }
     size_t difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion) const
     {
-        if (blockMajorVersion >= BLOCK_MAJOR_VERSION_3) {
+        if (blockMajorVersion >= BLOCK_MAJOR_VERSION_6) {
+            return difficultyBlocksCount6();
+        } else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_3) {
             return difficultyBlocksCount3() + 1;
         } else if (blockMajorVersion == BLOCK_MAJOR_VERSION_2) {
             return difficultyBlocksCount2();
@@ -111,6 +113,7 @@ public:
     size_t difficultyBlocksCount() const { return m_difficultyWindow + m_difficultyLag; }
     size_t difficultyBlocksCount2() const { return CryptoNote::parameters::DIFFICULTY_WINDOW_V2; }
     size_t difficultyBlocksCount3() const { return CryptoNote::parameters::DIFFICULTY_WINDOW_V3; }
+    size_t difficultyBlocksCount6() const { return CryptoNote::parameters::DIFFICULTY_WINDOW_V6; }
 
     size_t maxBlockSizeInitial() const { return m_maxBlockSizeInitial; }
     uint64_t maxBlockSizeGrowthSpeedNumerator() const { return m_maxBlockSizeGrowthSpeedNumerator; }

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -210,11 +210,10 @@ public:
 
     uint64_t roundUpMinFee(uint64_t minimalFee, int digits) const;
 
-    difficulty_type nextDifficulty(
-        uint32_t height,
+    difficulty_type nextDifficulty(uint32_t height,
         uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
-        std::vector<difficulty_type> Difficulties) const;
+        std::vector<difficulty_type> Difficulties, uint64_t block_time) const;
     difficulty_type nextDifficultyV1(
         std::vector<uint64_t> timestamps,
         std::vector<difficulty_type> Difficulties) const;
@@ -225,6 +224,10 @@ public:
         std::vector<uint64_t> timestamps,
         std::vector<difficulty_type> Difficulties) const;
     difficulty_type nextDifficultyV5(
+        uint8_t blockMajorVersion,
+        std::vector<uint64_t> timestamps,
+        std::vector<difficulty_type> Difficulties) const;
+    difficulty_type nextDifficultyV6(
         uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
         std::vector<difficulty_type> Difficulties) const;

--- a/lib/CryptoNoteCore/Currency.h
+++ b/lib/CryptoNoteCore/Currency.h
@@ -227,10 +227,9 @@ public:
         uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
         std::vector<difficulty_type> Difficulties) const;
-    difficulty_type nextDifficultyV6(
-        uint8_t blockMajorVersion,
+    difficulty_type nextDifficultyV6(uint8_t blockMajorVersion,
         std::vector<uint64_t> timestamps,
-        std::vector<difficulty_type> Difficulties) const;
+        std::vector<difficulty_type> Difficulties, uint64_t block_time) const;
 
     bool checkProofOfWorkV1(
         Crypto::cn_context &context,

--- a/lib/CryptoNoteCore/IMinerHandler.h
+++ b/lib/CryptoNoteCore/IMinerHandler.h
@@ -33,6 +33,23 @@ struct IMinerHandler
         uint32_t &height,
         const BinaryArray &ex_nonce) = 0;
 
+    enum stat_period
+    {
+        hour,
+        day,
+        week,
+        month,
+        year
+    };
+
+    virtual bool get_difficulty_stat(
+            uint32_t height,
+            stat_period period,
+            uint32_t &block_num,
+            uint64_t &avg_solve_time,
+            uint64_t &stddev_solve_time,
+            uint32_t &outliers_num) = 0;
+
 protected:
     ~IMinerHandler() = default;
 };

--- a/lib/Global/CryptoNoteConfig.h
+++ b/lib/Global/CryptoNoteConfig.h
@@ -113,6 +113,7 @@ const uint64_t EXPECTED_NUMBER_OF_BLOCKS_PER_DAY              = 24 * 60 * 60 / D
 const size_t   DIFFICULTY_WINDOW                              = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY; // blocks
 const size_t   DIFFICULTY_WINDOW_V2                           = DIFFICULTY_WINDOW;  // blocks
 const size_t   DIFFICULTY_WINDOW_V3                           = 70;  // blocks
+const size_t   DIFFICULTY_WINDOW_V6                           = 30;  // EXPECTED_NUMBER_OF_BLOCKS_PER_DAY / 24
 const size_t   DIFFICULTY_CUT                                 = 60;  // timestamps to cut after sorting
 const size_t   DIFFICULTY_LAG                                 = 15;  // !!!
 static_assert(2 * DIFFICULTY_CUT <= DIFFICULTY_WINDOW - 2, "Bad DIFFICULTY_WINDOW or DIFFICULTY_CUT");

--- a/lib/Global/CryptoNoteConfig.h
+++ b/lib/Global/CryptoNoteConfig.h
@@ -138,12 +138,20 @@ const size_t   FUSION_TX_MAX_SIZE                             = CRYPTONOTE_BLOCK
 const size_t   FUSION_TX_MIN_INPUT_COUNT                      = 12;
 const size_t   FUSION_TX_MIN_IN_OUT_COUNT_RATIO               = 4;
 
+/*
 const uint32_t UPGRADE_HEIGHT_V2                              = 20;
 const uint32_t UPGRADE_HEIGHT_V3                              = 30;
 const uint32_t UPGRADE_HEIGHT_V4                              = 40;
 const uint32_t UPGRADE_HEIGHT_V5                              = 50;
 const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 60;
 const uint32_t UPGRADE_HEIGHT_V6                              = 4294967295;
+*/
+const uint32_t UPGRADE_HEIGHT_V2                              = 1;
+const uint32_t UPGRADE_HEIGHT_V3                              = 2;
+const uint32_t UPGRADE_HEIGHT_V4                              = 3;
+const uint32_t UPGRADE_HEIGHT_V5                              = 4;
+const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 5;
+const uint32_t UPGRADE_HEIGHT_V6                              = 5;
 
 const unsigned UPGRADE_VOTING_THRESHOLD                      = 90; // percent
 const uint32_t UPGRADE_VOTING_WINDOW                         = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks

--- a/lib/Global/CryptoNoteConfig.h
+++ b/lib/Global/CryptoNoteConfig.h
@@ -138,20 +138,13 @@ const size_t   FUSION_TX_MAX_SIZE                             = CRYPTONOTE_BLOCK
 const size_t   FUSION_TX_MIN_INPUT_COUNT                      = 12;
 const size_t   FUSION_TX_MIN_IN_OUT_COUNT_RATIO               = 4;
 
-/*
-const uint32_t UPGRADE_HEIGHT_V2                              = 20;
-const uint32_t UPGRADE_HEIGHT_V3                              = 30;
-const uint32_t UPGRADE_HEIGHT_V4                              = 40;
-const uint32_t UPGRADE_HEIGHT_V5                              = 50;
-const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 60;
-const uint32_t UPGRADE_HEIGHT_V6                              = 4294967295;
-*/
-const uint32_t UPGRADE_HEIGHT_V2                              = 1;
-const uint32_t UPGRADE_HEIGHT_V3                              = 2;
-const uint32_t UPGRADE_HEIGHT_V4                              = 3;
-const uint32_t UPGRADE_HEIGHT_V5                              = 4;
-const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 5;
-const uint32_t UPGRADE_HEIGHT_V6                              = 5;
+
+const uint32_t UPGRADE_HEIGHT_V2                              = 69;
+const uint32_t UPGRADE_HEIGHT_V3                              = 70;
+const uint32_t UPGRADE_HEIGHT_V4                              = 71;
+const uint32_t UPGRADE_HEIGHT_V5                              = 72;
+const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 73;
+const uint32_t UPGRADE_HEIGHT_V6                              = 73;
 
 const unsigned UPGRADE_VOTING_THRESHOLD                      = 90; // percent
 const uint32_t UPGRADE_VOTING_WINDOW                         = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks

--- a/lib/Global/CryptoNoteConfig.h
+++ b/lib/Global/CryptoNoteConfig.h
@@ -117,6 +117,7 @@ const size_t   DIFFICULTY_CUT                                 = 60;  // timestam
 const size_t   DIFFICULTY_LAG                                 = 15;  // !!!
 static_assert(2 * DIFFICULTY_CUT <= DIFFICULTY_WINDOW - 2, "Bad DIFFICULTY_WINDOW or DIFFICULTY_CUT");
 const size_t DEFAULT_DIFFICULTY                               = 10000;
+const size_t FIXED_DIFFICULTY                                 = 0;
 
 static constexpr uint64_t POISSON_CHECK_TRIGGER               = 10;   // Reorg size that triggers poisson timestamp check
 static constexpr uint64_t POISSON_CHECK_DEPTH                 = 60;   // Main-chain depth of the poisson check. The attacker will have to tamper 50% of those blocks

--- a/lib/Global/CryptoNoteConfig.h
+++ b/lib/Global/CryptoNoteConfig.h
@@ -116,6 +116,7 @@ const size_t   DIFFICULTY_WINDOW_V3                           = 70;  // blocks
 const size_t   DIFFICULTY_CUT                                 = 60;  // timestamps to cut after sorting
 const size_t   DIFFICULTY_LAG                                 = 15;  // !!!
 static_assert(2 * DIFFICULTY_CUT <= DIFFICULTY_WINDOW - 2, "Bad DIFFICULTY_WINDOW or DIFFICULTY_CUT");
+const size_t DEFAULT_DIFFICULTY                               = 10000;
 
 static constexpr uint64_t POISSON_CHECK_TRIGGER               = 10;   // Reorg size that triggers poisson timestamp check
 static constexpr uint64_t POISSON_CHECK_DEPTH                 = 60;   // Main-chain depth of the poisson check. The attacker will have to tamper 50% of those blocks

--- a/lib/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/lib/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -1304,6 +1304,56 @@ struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH
     };
 };
 
+struct difficulty_statistics
+{
+    void serialize(ISerializer &s)
+    {
+        KV_MEMBER(block_num)
+        KV_MEMBER(avg_solve_time)
+        KV_MEMBER(stddev_solve_time)
+        KV_MEMBER(outliers_num)
+    }
+
+    uint32_t block_num;
+    uint64_t avg_solve_time;
+    uint64_t stddev_solve_time;
+    uint32_t outliers_num;
+};
+
+struct COMMAND_RPC_GET_DIFFICULTY_STAT
+{
+    struct request
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(height)
+        }
+
+        uint32_t height;
+
+    };
+
+    struct response
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(status)
+            KV_MEMBER(hour)
+            KV_MEMBER(day)
+            KV_MEMBER(week)
+            KV_MEMBER(month)
+            KV_MEMBER(year)
+        }
+
+        std::string status;
+        difficulty_statistics hour;
+        difficulty_statistics day;
+        difficulty_statistics week;
+        difficulty_statistics month;
+        difficulty_statistics year;
+    };
+};
+
 struct reserve_proof_entry
 {
     void serialize(ISerializer &s)

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -1018,7 +1018,7 @@ bool RpcServer::on_get_info(
     COMMAND_RPC_GET_INFO::response &res)
 {
     res.height = m_core.get_current_blockchain_height();
-    res.difficulty = m_core.getNextBlockDifficulty();
+    res.difficulty = m_core.getNextBlockDifficulty(time(nullptr));
     res.tx_count = m_core.get_blockchain_total_transactions() - res.height; // without coinbase
     res.tx_pool_size = m_core.get_pool_transactions_count();
     res.alt_blocks_count = m_core.get_alternative_blocks_count();

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -1021,7 +1021,7 @@ bool RpcServer::on_get_info(
     COMMAND_RPC_GET_INFO::response &res)
 {
     res.height = m_core.get_current_blockchain_height();
-    res.difficulty = m_core.getNextBlockDifficulty(time(nullptr));
+    res.difficulty = m_core.getNextBlockDifficulty();
     res.tx_count = m_core.get_blockchain_total_transactions() - res.height; // without coinbase
     res.tx_pool_size = m_core.get_pool_transactions_count();
     res.alt_blocks_count = m_core.get_alternative_blocks_count();

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -418,6 +418,9 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest &request, HttpResponse &
             },{
                 "verifymessage",
                 { makeMemberMethod(&RpcServer::on_verify_message), false }
+            },{
+                "get_difficulty_stat",
+                { makeMemberMethod(&RpcServer::on_get_difficulty_stat), false }
             }
         };
 
@@ -2569,6 +2572,57 @@ bool RpcServer::on_verify_message(
     memcpy(&s, decoded.data(), sizeof(s));
 
     res.sig_valid = Crypto::check_signature(hash, acc.spendPublicKey, s);
+    res.status = CORE_RPC_STATUS_OK;
+
+    return true;
+}
+
+bool RpcServer::on_get_difficulty_stat(const COMMAND_RPC_GET_DIFFICULTY_STAT::request &req, COMMAND_RPC_GET_DIFFICULTY_STAT::response &res)
+{
+    try {
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::hour,
+                                       res.hour.block_num,
+                                       res.hour.avg_solve_time,
+                                       res.hour.stddev_solve_time,
+                                       res.hour.outliers_num))
+            throw std::runtime_error("Failed to get hour difficulty statistics");
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::day,
+                                       res.day.block_num,
+                                       res.day.avg_solve_time,
+                                       res.day.stddev_solve_time,
+                                       res.day.outliers_num))
+            throw std::runtime_error("Failed to get day difficulty statistics");
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::week,
+                                       res.week.block_num,
+                                       res.week.avg_solve_time,
+                                       res.week.stddev_solve_time,
+                                       res.week.outliers_num))
+            throw std::runtime_error("Failed to get week difficulty statistics");
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::month,
+                                       res.month.block_num,
+                                       res.month.avg_solve_time,
+                                       res.month.stddev_solve_time,
+                                       res.month.outliers_num))
+            throw std::runtime_error("Failed to get month difficulty statistics");
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::year,
+                                       res.year.block_num,
+                                       res.year.avg_solve_time,
+                                       res.year.stddev_solve_time,
+                                       res.year.outliers_num))
+            throw std::runtime_error("Failed to get month difficulty statistics");
+    } catch (std::system_error &e) {
+        res.status = e.what();
+        return false;
+    } catch (std::exception &e) {
+        res.status = "Error: " + std::string(e.what());
+        return false;
+    }
+
     res.status = CORE_RPC_STATUS_OK;
 
     return true;

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -261,6 +261,9 @@ std::unordered_map<
     },{
         "/stop_daemon",
         { jsonMethod<COMMAND_RPC_STOP_DAEMON>(&RpcServer::on_stop_daemon), true }
+    },{
+        "/get_difficulty_stat",
+        { jsonMethod<COMMAND_RPC_GET_DIFFICULTY_STAT>(&RpcServer::on_get_difficulty_stat), false }
     },
 
     // json rpc
@@ -418,9 +421,6 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest &request, HttpResponse &
             },{
                 "verifymessage",
                 { makeMemberMethod(&RpcServer::on_verify_message), false }
-            },{
-                "get_difficulty_stat",
-                { makeMemberMethod(&RpcServer::on_get_difficulty_stat), false }
             }
         };
 

--- a/lib/Rpc/RpcServer.h
+++ b/lib/Rpc/RpcServer.h
@@ -229,6 +229,10 @@ private:
         const COMMAND_RPC_VERIFY_MESSAGE::request &req,
         COMMAND_RPC_VERIFY_MESSAGE::response &res);
 
+    bool on_get_difficulty_stat(
+        const COMMAND_RPC_GET_DIFFICULTY_STAT::request &req,
+        COMMAND_RPC_GET_DIFFICULTY_STAT::response &res);
+
     bool f_getMixin(const Transaction &transaction, uint64_t &mixin);
 
 private:

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -243,7 +243,7 @@ bool DaemonCommandsHandler::help(const std::vector<std::string> &args)
 bool DaemonCommandsHandler::status(const std::vector<std::string> &args)
 {
     uint32_t height = m_core.get_current_blockchain_height() - 1;
-    uint64_t difficulty = m_core.getNextBlockDifficulty();
+    uint64_t difficulty = m_core.getNextBlockDifficulty(time(nullptr));
     size_t tx_pool_size = m_core.get_pool_transactions_count();
     size_t alt_blocks_count = m_core.get_alternative_blocks_count();
     uint32_t last_known_block_index = std::max(
@@ -523,7 +523,7 @@ bool DaemonCommandsHandler::print_diff(const std::vector<std::string> &args)
 {
     logger(Logging::INFO)
         << "Difficulty for next block: "
-        << m_core.getNextBlockDifficulty()
+        << m_core.getNextBlockDifficulty(time(nullptr))
         << std::endl;
 
     return true;

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -249,7 +249,7 @@ bool DaemonCommandsHandler::help(const std::vector<std::string> &args)
 bool DaemonCommandsHandler::status(const std::vector<std::string> &args)
 {
     uint32_t height = m_core.get_current_blockchain_height() - 1;
-    uint64_t difficulty = m_core.getNextBlockDifficulty(time(nullptr));
+    uint64_t difficulty = m_core.getNextBlockDifficulty();
     size_t tx_pool_size = m_core.get_pool_transactions_count();
     size_t alt_blocks_count = m_core.get_alternative_blocks_count();
     uint32_t last_known_block_index = std::max(
@@ -529,7 +529,7 @@ bool DaemonCommandsHandler::print_diff(const std::vector<std::string> &args)
 {
     logger(Logging::INFO)
         << "Difficulty for next block: "
-        << m_core.getNextBlockDifficulty(time(nullptr))
+        << m_core.getNextBlockDifficulty()
         << std::endl;
 
     return true;

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -160,6 +160,12 @@ DaemonCommandsHandler::DaemonCommandsHandler(
     );
 
     m_consoleHandler.setHandler(
+        "print_diff_stat",
+        boost::bind(&DaemonCommandsHandler::print_diff_stat, this, _1),
+        "Difficulty statistics for given height"
+    );
+
+    m_consoleHandler.setHandler(
         "print_ban",
         boost::bind(&DaemonCommandsHandler::print_ban, this, _1),
         "Print banned nodes"
@@ -525,6 +531,96 @@ bool DaemonCommandsHandler::print_diff(const std::vector<std::string> &args)
         << "Difficulty for next block: "
         << m_core.getNextBlockDifficulty(time(nullptr))
         << std::endl;
+
+    return true;
+}
+
+bool DaemonCommandsHandler::print_diff_stat(const std::vector<std::string> &args)
+{
+    if(args.size() != 1) {
+        logger(Logging::INFO) << "expected print_diff_stat <height>";
+        return true;
+    }
+    uint32_t height = boost::lexical_cast<uint32_t>(args[0]);
+    uint32_t block_num;
+    uint64_t avg_solve_time;
+    uint64_t stddev_solve_time;
+    uint32_t outliers_num;
+    if (m_core.get_difficulty_stat(
+                height,
+                CryptoNote::IMinerHandler::stat_period::hour,
+                block_num,
+                avg_solve_time,
+                stddev_solve_time,
+                outliers_num))
+        logger(Logging::INFO)
+            << "Difficulty stat for hour: "
+            << std::endl
+            << "Blocks: " << block_num << ", "
+            << "avg solve time: " << avg_solve_time << ", "
+            << "stddev: " << stddev_solve_time << ", "
+            << "outliers: " << outliers_num
+            << std::endl;
+    if (m_core.get_difficulty_stat(
+                height,
+                CryptoNote::IMinerHandler::stat_period::day,
+                block_num,
+                avg_solve_time,
+                stddev_solve_time,
+                outliers_num))
+        logger(Logging::INFO)
+            << "Difficulty stat for day: "
+            << std::endl
+            << "Blocks: " << block_num << ", "
+            << "avg solve time: " << avg_solve_time << ", "
+            << "stddev: " << stddev_solve_time << ", "
+            << "outliers: " << outliers_num
+            << std::endl;
+    if (m_core.get_difficulty_stat(
+                height,
+                CryptoNote::IMinerHandler::stat_period::week,
+                block_num,
+                avg_solve_time,
+                stddev_solve_time,
+                outliers_num))
+        logger(Logging::INFO)
+            << "Difficulty stat for week: "
+            << std::endl
+            << "Blocks: " << block_num << ", "
+            << "avg solve time: " << avg_solve_time << ", "
+            << "stddev: " << stddev_solve_time << ", "
+            << "outliers: " << outliers_num
+            << std::endl;
+    if (m_core.get_difficulty_stat(
+                height,
+                CryptoNote::IMinerHandler::stat_period::month,
+                block_num,
+                avg_solve_time,
+                stddev_solve_time,
+                outliers_num))
+        logger(Logging::INFO)
+            << "Difficulty stat for month: "
+            << std::endl
+            << "Blocks: " << block_num << ", "
+            << "avg solve time: " << avg_solve_time << ", "
+            << "stddev: " << stddev_solve_time << ", "
+            << "outliers: " << outliers_num
+            << std::endl;
+    if (m_core.get_difficulty_stat(
+                height,
+                CryptoNote::IMinerHandler::stat_period::year,
+                block_num,
+                avg_solve_time,
+                stddev_solve_time,
+                outliers_num))
+        logger(Logging::INFO)
+            << "Difficulty stat for year: "
+            << std::endl
+            << "Blocks: " << block_num << ", "
+            << "avg solve time: " << avg_solve_time << ", "
+            << "stddev: " << stddev_solve_time << ", "
+            << "outliers: " << outliers_num
+            << std::endl;
 
     return true;
 }

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -160,7 +160,7 @@ DaemonCommandsHandler::DaemonCommandsHandler(
     );
 
     m_consoleHandler.setHandler(
-        "print_diff_stat",
+        "diff_stat",
         boost::bind(&DaemonCommandsHandler::print_diff_stat, this, _1),
         "Difficulty statistics for given height"
     );

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -85,6 +85,7 @@ private:
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);
     bool print_diff(const std::vector<std::string> &args);
+    bool print_diff_stat(const std::vector<std::string> &args);
     bool print_ban(const std::vector<std::string> &args);
     bool ban(const std::vector<std::string> &args);
     bool unban(const std::vector<std::string> &args);

--- a/src/Miner/MinerManager.cpp
+++ b/src/Miner/MinerManager.cpp
@@ -62,7 +62,7 @@ void adjustMergeMiningTag(Block& blockTemplate)
         }
 
         blockTemplate.parentBlock.baseTransaction.extra.clear();
-        auto extra = blockTemplate.parentBlock.baseTransaction.extra;
+        auto& extra = blockTemplate.parentBlock.baseTransaction.extra;
         if (!CryptoNote::appendMergeMiningTagToExtra(extra, mmTag)) {
             throw std::runtime_error("Couldn't append merge mining tag");
         }


### PR DESCRIPTION
Requires testnet reset (important config parameters are changed).

New algorithm description:
```
    uint32_t difficultyWindow = size of input arrays with block timestamps and difficulties
    uint64_t avgSolvetime = difference of timestamp between first height in input data and current height divided by available difficulty window
    uint64_t stdSolvetime = standard deviation of solvetime of available difficulty window
    uint64_t validSample[] = only count the number of heights that does not outlie avgSolvetime +/- stdSolvetime 
    uint64_t realAvgSolvetime = average of validSample's solvetime divided by validSample
    difficulty_type previousDiff = last difficulty value among validSamples
    difficulty_type defaultDiff = minimal possible difficulty value from config params,  now it is 10000

    if (height < minimal_required_height)
       nextDiffV6 = defaultDiff;
    if (realAvgSolvetime < difficultyTarget) {
        nextDiffV6 = previousDiff * min(1.2,(difficultyTarget/realAvgSolvetime));
    } else if (realAvgSolvetime > difficultyTarget) {
        nextDiffV6 = max(defaultDiff, previousDiff * (difficultyTarget/realAvgSolvetime));
    } else {
        nextDiffV6 = previousDiff;
    }
```

I've tested it with private testnet.