### PR TITLE
Wallet rescan and shrink operations

### DIFF
--- a/include/INode.h
+++ b/include/INode.h
@@ -106,6 +106,7 @@ public:
     virtual uint64_t getLastLocalBlockTimestamp() const = 0;
     virtual uint32_t getNodeHeight() const = 0;
     virtual BlockHeaderInfo getLastLocalBlockHeaderInfo() const = 0;
+    virtual uint32_t getGRBHeight() const = 0;
 
     virtual void relayTransaction(const Transaction &transaction, const Callback &callback) = 0;
     virtual void getRandomOutsByAmounts(

--- a/lib/InProcessNode/InProcessNode.cpp
+++ b/lib/InProcessNode/InProcessNode.cpp
@@ -496,6 +496,12 @@ BlockHeaderInfo InProcessNode::getLastLocalBlockHeaderInfo() const
     return lastLocalBlockHeaderInfo;
 }
 
+uint32_t InProcessNode::getGRBHeight() const
+{
+    // stub, not implemented yet
+    return getLocalBlockCount();
+}
+
 void InProcessNode::peerCountUpdated(size_t count)
 {
     observerManager.notify(&INodeObserver::peerCountUpdated, count);

--- a/lib/InProcessNode/InProcessNode.h
+++ b/lib/InProcessNode/InProcessNode.h
@@ -58,6 +58,7 @@ public:
     uint64_t getLastLocalBlockTimestamp() const override;
     uint64_t getMinimalFee() const override;
     BlockHeaderInfo getLastLocalBlockHeaderInfo() const override;
+    uint32_t getGRBHeight() const override;
 
     void getNewBlocks(std::vector<Crypto::Hash> &&knownBlockIds,
                       std::vector<CryptoNote::block_complete_entry> &newBlocks,

--- a/lib/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/lib/NodeRpcProxy/NodeRpcProxy.cpp
@@ -293,6 +293,9 @@ void NodeRpcProxy::updateBlockchainStatus()
             m_networkHeight.store(lastKnownBlockIndex, std::memory_order_relaxed);
             m_observerManager.notify(&INodeObserver::lastKnownBlockHeightUpdated,
                                      m_networkHeight.load(std::memory_order_relaxed));
+            m_state = STATE_INITIALIZING;
+        } else {
+            m_state = STATE_INITIALIZED;
         }
 
         updatePeerCount(getInfoResp.incoming_connections_count
@@ -648,11 +651,12 @@ void NodeRpcProxy::isSynchronized(bool &syncStatus, const Callback &callback)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_state != STATE_INITIALIZED) {
+        syncStatus = false;
         callback(make_error_code(error::NOT_INITIALIZED));
         return;
     }
 
-    // TODO: NOT IMPLEMENTED!
+    syncStatus = true;
     callback(std::error_code{});
 }
 

--- a/lib/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/lib/NodeRpcProxy/NodeRpcProxy.cpp
@@ -294,9 +294,6 @@ void NodeRpcProxy::updateBlockchainStatus()
             m_networkHeight.store(lastKnownBlockIndex, std::memory_order_relaxed);
             m_observerManager.notify(&INodeObserver::lastKnownBlockHeightUpdated,
                                      m_networkHeight.load(std::memory_order_relaxed));
-            m_state = STATE_INITIALIZING;
-        } else {
-            m_state = STATE_INITIALIZED;
         }
 
         updatePeerCount(getInfoResp.incoming_connections_count
@@ -663,7 +660,7 @@ void NodeRpcProxy::isSynchronized(bool &syncStatus, const Callback &callback)
         return;
     }
 
-    syncStatus = true;
+    syncStatus = (lastLocalBlockHeaderInfo.index == m_networkHeight);
     callback(std::error_code{});
 }
 

--- a/lib/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/lib/NodeRpcProxy/NodeRpcProxy.cpp
@@ -140,6 +140,7 @@ void NodeRpcProxy::resetInternalState()
     m_stop = false;
     m_peerCount.store(0, std::memory_order_relaxed);
     m_networkHeight.store(0, std::memory_order_relaxed);
+    m_GRBHeight.store(0, std::memory_order_relaxed);
     lastLocalBlockHeaderInfo.index = 0;
     lastLocalBlockHeaderInfo.majorVersion = 0;
     lastLocalBlockHeaderInfo.minorVersion = 0;
@@ -303,6 +304,7 @@ void NodeRpcProxy::updateBlockchainStatus()
 
         m_minimalFee.store(getInfoResp.min_tx_fee, std::memory_order_relaxed);
         m_nodeHeight.store(getInfoResp.height, std::memory_order_relaxed);
+        m_GRBHeight.store(getInfoResp.height, std::memory_order_relaxed);
     }
 
     if (m_connected != m_httpClient->isConnected()) {
@@ -405,6 +407,11 @@ BlockHeaderInfo NodeRpcProxy::getLastLocalBlockHeaderInfo() const
     std::lock_guard<std::mutex> lock(m_mutex);
 
     return lastLocalBlockHeaderInfo;
+}
+
+uint32_t NodeRpcProxy::getGRBHeight() const
+{
+    return m_GRBHeight;
 }
 
 uint32_t NodeRpcProxy::getNodeHeight() const

--- a/lib/NodeRpcProxy/NodeRpcProxy.h
+++ b/lib/NodeRpcProxy/NodeRpcProxy.h
@@ -80,6 +80,7 @@ public:
     uint64_t getMinimalFee() const override;
     uint32_t getNodeHeight() const override;
     BlockHeaderInfo getLastLocalBlockHeaderInfo() const override;
+    uint32_t getGRBHeight() const override;
 
     void relayTransaction(const CryptoNote::Transaction &transaction,
                           const Callback &callback) override;
@@ -208,6 +209,7 @@ private:
     std::atomic<uint32_t> m_networkHeight;
     std::atomic<uint64_t> m_nodeHeight;
     std::atomic<uint64_t> m_minimalFee;
+    std::atomic<uint32_t> m_GRBHeight;
 
     BlockHeaderInfo lastLocalBlockHeaderInfo;
     // protect it with mutex if decided to add worker threads

--- a/lib/PaymentGate/NodeFactory.cpp
+++ b/lib/PaymentGate/NodeFactory.cpp
@@ -47,6 +47,7 @@ public:
     {
         return CryptoNote::BlockHeaderInfo{};
     }
+    uint32_t getGRBHeight() const override { return 0; };
 
     void relayTransaction(const CryptoNote::Transaction &transaction,
                           const Callback &callback) override

--- a/lib/Serialization/SerializationOverloads.cpp
+++ b/lib/Serialization/SerializationOverloads.cpp
@@ -17,6 +17,7 @@
 // along with Qwertycoin.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <limits>
+#include <stdexcept>
 #include <Serialization/SerializationOverloads.h>
 
 namespace CryptoNote {

--- a/lib/Wallet/WalletRpcServer.cpp
+++ b/lib/Wallet/WalletRpcServer.cpp
@@ -142,6 +142,7 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest &request,
             { "store"            , makeMemberMethod(&wallet_rpc_server::on_store)             },
             { "stop_wallet"      , makeMemberMethod(&wallet_rpc_server::on_stop_wallet)       },
             { "reset"            , makeMemberMethod(&wallet_rpc_server::on_reset)             },
+            { "purge"            , makeMemberMethod(&wallet_rpc_server::on_purge)             },
             { "get_payments"     , makeMemberMethod(&wallet_rpc_server::on_get_payments)      },
             { "get_messages"	 , makeMemberMethod(&wallet_rpc_server::on_get_messages)	  },
             { "get_transfers"    , makeMemberMethod(&wallet_rpc_server::on_get_transfers)     },
@@ -573,6 +574,15 @@ bool wallet_rpc_server::on_reset(
     wallet_rpc::COMMAND_RPC_RESET::response &res)
 {
     m_wallet.reset();
+
+    return true;
+}
+
+bool wallet_rpc_server::on_purge(
+    const wallet_rpc::COMMAND_RPC_PURGE::request &req,
+    wallet_rpc::COMMAND_RPC_PURGE::response &res)
+{
+    m_wallet.purge();
 
     return true;
 }

--- a/lib/Wallet/WalletRpcServer.cpp
+++ b/lib/Wallet/WalletRpcServer.cpp
@@ -141,7 +141,7 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest &request,
             { "transfer"         , makeMemberMethod(&wallet_rpc_server::on_transfer)          },
             { "store"            , makeMemberMethod(&wallet_rpc_server::on_store)             },
             { "stop_wallet"      , makeMemberMethod(&wallet_rpc_server::on_stop_wallet)       },
-            { "reset"            , makeMemberMethod(&wallet_rpc_server::on_reset)             },
+            { "rescan"           , makeMemberMethod(&wallet_rpc_server::on_rescan)            },
             { "purge"            , makeMemberMethod(&wallet_rpc_server::on_purge)             },
             { "get_payments"     , makeMemberMethod(&wallet_rpc_server::on_get_payments)      },
             { "get_messages"	 , makeMemberMethod(&wallet_rpc_server::on_get_messages)	  },
@@ -569,11 +569,11 @@ bool wallet_rpc_server::on_query_key(
     return true;
 }
 
-bool wallet_rpc_server::on_reset(
-    const wallet_rpc::COMMAND_RPC_RESET::request &req,
-    wallet_rpc::COMMAND_RPC_RESET::response &res)
+bool wallet_rpc_server::on_rescan(
+    const wallet_rpc::COMMAND_RPC_RESCAN::request &req,
+    wallet_rpc::COMMAND_RPC_RESCAN::response &res)
 {
-    m_wallet.reset();
+    m_wallet.rescan();
 
     return true;
 }

--- a/lib/Wallet/WalletRpcServer.h
+++ b/lib/Wallet/WalletRpcServer.h
@@ -123,9 +123,9 @@ private:
 	bool on_validate_address(
 	    const wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::request &req,
 	    wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::response &res);
-	bool on_reset(
-	    const wallet_rpc::COMMAND_RPC_RESET::request &req,
-	    wallet_rpc::COMMAND_RPC_RESET::response &res);
+    bool on_rescan(
+        const wallet_rpc::COMMAND_RPC_RESCAN::request &req,
+        wallet_rpc::COMMAND_RPC_RESCAN::response &res);
     bool on_purge(
         const wallet_rpc::COMMAND_RPC_PURGE::request &req,
         wallet_rpc::COMMAND_RPC_PURGE::response &res);

--- a/lib/Wallet/WalletRpcServer.h
+++ b/lib/Wallet/WalletRpcServer.h
@@ -126,6 +126,9 @@ private:
 	bool on_reset(
 	    const wallet_rpc::COMMAND_RPC_RESET::request &req,
 	    wallet_rpc::COMMAND_RPC_RESET::response &res);
+    bool on_purge(
+        const wallet_rpc::COMMAND_RPC_PURGE::request &req,
+        wallet_rpc::COMMAND_RPC_PURGE::response &res);
 
     bool handle_command_line(const boost::program_options::variables_map& vm);
 

--- a/lib/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/lib/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -319,6 +319,13 @@ struct COMMAND_RPC_RESET
     typedef CryptoNote::EMPTY_STRUCT response;
 };
 
+// command: purge
+struct COMMAND_RPC_PURGE
+{
+    typedef CryptoNote::EMPTY_STRUCT request;
+    typedef CryptoNote::EMPTY_STRUCT response;
+};
+
 // command: query_key
 struct COMMAND_RPC_QUERY_KEY
 {

--- a/lib/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/lib/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -313,7 +313,7 @@ struct COMMAND_RPC_GET_HEIGHT
 };
 
 // command: reset
-struct COMMAND_RPC_RESET
+struct COMMAND_RPC_RESCAN
 {
     typedef CryptoNote::EMPTY_STRUCT request;
     typedef CryptoNote::EMPTY_STRUCT response;

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -132,7 +132,7 @@ public:
     virtual void initAndLoad(std::istream &source, const std::string &password) = 0;
     virtual void initWithKeys(const AccountKeys &accountKeys, const std::string &password) = 0;
     virtual void shutdown() = 0;
-    virtual void reset() = 0;
+    virtual void rescan() = 0;
     virtual void purge() = 0;
 
     virtual void save(std::ostream &destination, bool saveDetailed = true, bool saveCache = true)=0;

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -215,6 +215,9 @@ public:
         const std::string &signature) = 0;
 
     virtual bool isTrackingWallet() = 0;
+
+    virtual void setShrinkHeight(uint32_t height) = 0;
+    virtual uint32_t getShrinkHeight() const = 0;
 };
 
 } // namespace CryptoNOte

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -133,6 +133,7 @@ public:
     virtual void initWithKeys(const AccountKeys &accountKeys, const std::string &password) = 0;
     virtual void shutdown() = 0;
     virtual void reset() = 0;
+    virtual void purge() = 0;
 
     virtual void save(std::ostream &destination, bool saveDetailed = true, bool saveCache = true)=0;
 

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -151,6 +151,8 @@ public:
     virtual size_t getTransferCount() = 0;
     virtual size_t getUnlockedOutputsCount() = 0;
 
+    virtual std::list<TransactionOutputInformation> selectAllOldOutputs(uint32_t height) = 0;
+
     virtual TransactionId findTransactionByTransferId(TransferId transferId) = 0;
 
     virtual bool getTransaction(TransactionId transactionId,WalletLegacyTransaction &transaction)=0;

--- a/lib/WalletLegacy/WalletLegacy.cpp
+++ b/lib/WalletLegacy/WalletLegacy.cpp
@@ -1191,6 +1191,16 @@ bool WalletLegacy::isTrackingWallet()
     return keys.spendSecretKey == boost::value_initialized<Crypto::SecretKey>();
 }
 
+void WalletLegacy::setShrinkHeight(uint32_t height)
+{
+    m_transactionsCache.setShrinkHeight(height);
+}
+
+uint32_t WalletLegacy::getShrinkHeight() const
+{
+    return m_transactionsCache.getShrinkHeight();
+}
+
 std::vector<TransactionId> WalletLegacy::deleteOutdatedUnconfirmedTransactions()
 {
     std::lock_guard<std::mutex> lock(m_cacheMutex);

--- a/lib/WalletLegacy/WalletLegacy.cpp
+++ b/lib/WalletLegacy/WalletLegacy.cpp
@@ -301,7 +301,7 @@ void WalletLegacy::initSync()
     AccountSubscription sub;
     sub.keys = reinterpret_cast<const AccountKeys &>(m_account.getAccountKeys());
     sub.transactionSpendableAge = CryptoNote::parameters::CRYPTONOTE_TX_SPENDABLE_AGE;
-    sub.syncStart.height = 0;
+    sub.syncStart.height = m_transactionsCache.getShrinkHeight();
     sub.syncStart.timestamp = m_account.get_createtime() - ACCOUNT_CREATE_TIME_ACCURACY;
 
     auto &subObject = m_transfersSync.addSubscription(sub);

--- a/lib/WalletLegacy/WalletLegacy.cpp
+++ b/lib/WalletLegacy/WalletLegacy.cpp
@@ -414,7 +414,7 @@ void WalletLegacy::shutdown()
     }
 }
 
-void WalletLegacy::reset()
+void WalletLegacy::rescan()
 {
     try {
         std::error_code saveError;
@@ -423,7 +423,7 @@ void WalletLegacy::reset()
         {
             SaveWaiter saveWaiter;
             WalletHelper::IWalletRemoveObserverGuard saveGuarantee(*this, saveWaiter);
-            save(ss, false, false);
+            save(ss, true, true);
             saveError = saveWaiter.waitSave();
         }
 

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -103,6 +103,8 @@ public:
     size_t getTransferCount() override;
     size_t getUnlockedOutputsCount() override;
 
+    std::list<TransactionOutputInformation> selectAllOldOutputs(uint32_t height) override;
+
     TransactionId findTransactionByTransferId(TransferId transferId) override;
 
     bool getTransaction(TransactionId transactionId, WalletLegacyTransaction &transaction) override;

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -167,6 +167,9 @@ public:
 
     bool isTrackingWallet() override;
 
+    void setShrinkHeight(uint32_t height) override;
+    uint32_t getShrinkHeight() const override;
+
 private:
     // IBlockchainSynchronizerObserver
     void synchronizationProgressUpdated(uint32_t current, uint32_t total) override;

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -79,6 +79,7 @@ public:
     void initWithKeys(const AccountKeys &accountKeys, const std::string &password) override;
     void shutdown() override;
     void reset() override;
+    void purge() override;
 
     Crypto::SecretKey generateKey(
         const std::string &password,

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -78,7 +78,7 @@ public:
     void initAndLoad(std::istream &source, const std::string &password) override;
     void initWithKeys(const AccountKeys &accountKeys, const std::string &password) override;
     void shutdown() override;
-    void reset() override;
+    void rescan() override;
     void purge() override;
 
     Crypto::SecretKey generateKey(

--- a/lib/WalletLegacy/WalletLegacySerializer.cpp
+++ b/lib/WalletLegacy/WalletLegacySerializer.cpp
@@ -35,13 +35,13 @@ using namespace Common;
 
 namespace CryptoNote {
 
-uint32_t WALLET_LEGACY_SERIALIZATION_VERSION = 2;
+uint32_t WALLET_LEGACY_SERIALIZATION_VERSION = 3;
 
 WalletLegacySerializer::WalletLegacySerializer(CryptoNote::AccountBase &account,
                                                WalletUserTransactionsCache &transactionsCache)
     : account(account),
       transactionsCache(transactionsCache),
-      walletSerializationVersion(2)
+      walletSerializationVersion(3)
 {
 }
 
@@ -66,6 +66,10 @@ void WalletLegacySerializer::serialize(
     }
 
     serializer.binary(const_cast<std::string &>(cache), "cache");
+    if (walletSerializationVersion >= 3) {
+        uint32_t shrinkHeight = transactionsCache.getShrinkHeight();
+        serializer(shrinkHeight, "shrink_height");
+    }
 
     std::string plain = plainArchive.str();
     std::string cipher;
@@ -170,6 +174,11 @@ void WalletLegacySerializer::deserialize(
     }
 
     serializer.binary(cache, "cache");
+    if (version >= 3) {
+        uint32_t shrinkHeight = 0;
+        serializer(shrinkHeight, "shrink_height");
+        transactionsCache.setShrinkHeight(shrinkHeight);
+    }
 }
 
 void WalletLegacySerializer::decrypt(

--- a/lib/WalletLegacy/WalletUserTransactionsCache.cpp
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.cpp
@@ -410,24 +410,17 @@ void WalletUserTransactionsCache::getGoodItems(
     UserTransactions &transactions,
     UserTransfers &transfers)
 {
-    size_t offset = 0;
-
     for (size_t txId = 0; txId < m_transactions.size(); ++txId) {
         bool isGood = m_transactions[txId].state != WalletLegacyTransactionState::Cancelled
                       && m_transactions[txId].state != WalletLegacyTransactionState::Failed;
 
-        if (isGood) {
-            getGoodTransaction(txId, offset, transactions, transfers);
-        } else {
-            const WalletLegacyTransaction &t = m_transactions[txId];
-            offset += t.firstTransferId != WALLET_LEGACY_INVALID_TRANSFER_ID ? t.transferCount : 0;
-        }
+        if (isGood)
+            getGoodTransaction(txId, transactions, transfers);
     }
 }
 
 void WalletUserTransactionsCache::getGoodTransaction(
     TransactionId txId,
-    size_t offset,
     UserTransactions &transactions,
     UserTransfers &transfers)
 {
@@ -441,9 +434,8 @@ void WalletUserTransactionsCache::getGoodTransaction(
     UserTransfers::const_iterator first = m_transfers.begin() + tx.firstTransferId;
     UserTransfers::const_iterator last = first + tx.transferCount;
 
-    tx.firstTransferId -= offset;
-
     std::copy(first, last, std::back_inserter(transfers));
+    tx.firstTransferId = transfers.size() - tx.transferCount;
 }
 
 void WalletUserTransactionsCache::getTransfersByTx(

--- a/lib/WalletLegacy/WalletUserTransactionsCache.cpp
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.cpp
@@ -33,7 +33,8 @@ using namespace Crypto;
 namespace CryptoNote {
 
 WalletUserTransactionsCache::WalletUserTransactionsCache(uint64_t mempoolTxLiveTime)
-    : m_unconfirmedTransactions(mempoolTxLiveTime)
+    : m_unconfirmedTransactions(mempoolTxLiveTime),
+      m_shrinkHeight(0)
 {
 }
 
@@ -47,6 +48,7 @@ bool WalletUserTransactionsCache::serialize(CryptoNote::ISerializer &s)
         updateUnconfirmedTransactions();
         deleteOutdatedTransactions();
         rebuildPaymentsIndex();
+        // m_shrinkHeight is serialized outside this method
     } else {
         UserTransactions txsToSave;
         UserTransfers transfersToSave;
@@ -55,6 +57,7 @@ bool WalletUserTransactionsCache::serialize(CryptoNote::ISerializer &s)
         s(txsToSave, "transactions");
         s(transfersToSave, "transfers");
         s(m_unconfirmedTransactions, "unconfirmed");
+        // m_shrinkHeight is serialized outside this method
     }
 
     return true;

--- a/lib/WalletLegacy/WalletUserTransactionsCache.h
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.h
@@ -96,9 +96,7 @@ private:
     using UserPaymentIndex=std::unordered_map<PaymentId,std::vector<Offset>,boost::hash<PaymentId>>;
 
     void getGoodItems(UserTransactions &transactions, UserTransfers &transfers);
-    void getGoodTransaction(
-        TransactionId txId,
-        size_t offset,
+    void getGoodTransaction(TransactionId txId,
         UserTransactions &transactions,
         UserTransfers &transfers);
 

--- a/lib/WalletLegacy/WalletUserTransactionsCache.h
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.h
@@ -87,6 +87,9 @@ public:
 
     std::vector<Payments> getTransactionsByPaymentIds(const std::vector<PaymentId>&paymentIds)const;
 
+    void setShrinkHeight(uint32_t height) { m_shrinkHeight = height; };
+    uint32_t getShrinkHeight() const { return m_shrinkHeight; };
+
 private:
     TransactionId insertTransaction(WalletLegacyTransaction &&Transaction);
     TransferId insertTransfers(const std::vector<WalletLegacyTransfer> &transfers);
@@ -115,6 +118,7 @@ private:
     UserTransfers m_transfers;
     WalletUnconfirmedTransactions m_unconfirmedTransactions;
     UserPaymentIndex m_paymentsIndex;
+    uint32_t m_shrinkHeight;
 };
 
 } // namespace CryptoNote

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -3299,6 +3299,12 @@ bool simple_wallet::shrink(const std::vector<std::string> &args)
         mixIn = 3;
     }
 
+    uint32_t currentShrinkHeight = m_wallet->getShrinkHeight();
+    if (currentShrinkHeight >= heightThreshold) {
+        fail_msg_writer() << "Wallet already shrinked up to " << currentShrinkHeight << " height";
+        return true;
+    }
+
     std::list<TransactionOutputInformation> oldInputs = m_wallet->selectAllOldOutputs(heightThreshold);
 
     if (oldInputs.empty()) {

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -3340,6 +3340,8 @@ bool simple_wallet::shrink(const std::vector<std::string> &args)
             << "Fusion transaction successfully sent, hash: "
             << Common::podToHex(txInfo.hash);
 
+        m_wallet->setShrinkHeight(heightThreshold);
+
         try {
             CryptoNote::WalletHelper::storeWallet(*m_wallet, m_wallet_file);
         } catch (const std::exception &e) {

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -187,9 +187,9 @@ const command_line::arg_descriptor<bool> arg_testnet = {
     "Used to deploy test nets. The daemon must be launched with --testnet flag",
     false
 };
-const command_line::arg_descriptor<bool> arg_reset = {
-    "reset",
-    "Discard cache data and start synchronizing from scratch",
+const command_line::arg_descriptor<bool> arg_rescan = {
+    "rescan",
+    "Start synchronizing from scratch",
     false
 };
 const command_line::arg_descriptor<bool> arg_purge = {
@@ -1160,9 +1160,9 @@ simple_wallet::simple_wallet(
         "Save wallet synchronized data"
     );
     m_consoleHandler.setHandler(
-        "reset",
-        boost::bind(&simple_wallet::reset, this, _1),
-        "Discard cache data and start synchronizing from the start"
+        "rescan",
+        boost::bind(&simple_wallet::rescan, this, _1),
+        "Start synchronizing from the scratch"
     );
     m_consoleHandler.setHandler(
         "show_seed",
@@ -1857,8 +1857,8 @@ bool simple_wallet::init(const boost::program_options::variables_map &vm)
             << "Use \"help\" command to see the list of available commands.\n"
             << "**********************************************************************";
 
-        if (command_line::has_arg(vm, arg_reset)) {
-            reset({});
+        if (command_line::has_arg(vm, arg_rescan)) {
+            rescan({});
         }
         if (command_line::has_arg(vm, arg_purge)) {
             purge({});
@@ -2234,15 +2234,15 @@ bool simple_wallet::save(const std::vector<std::string> &args)
     return true;
 }
 
-bool simple_wallet::reset(const std::vector<std::string> &args)
+bool simple_wallet::rescan(const std::vector<std::string> &args)
 {
     {
         std::unique_lock<std::mutex> lock(m_walletSynchronizedMutex);
         m_walletSynchronized = false;
     }
 
-    m_wallet->reset();
-    success_msg_writer(true) << "Reset completed successfully.";
+    m_wallet->rescan();
+    success_msg_writer(true) << "Rescan completed successfully.";
 
     std::unique_lock<std::mutex> lock(m_walletSynchronizedMutex);
     while (!m_walletSynchronized) {
@@ -3350,7 +3350,7 @@ int main(int argc, char *argv[])
     command_line::add_arg(desc_params, arg_log_file);
     command_line::add_arg(desc_params, arg_log_level);
     command_line::add_arg(desc_params, arg_testnet);
-    command_line::add_arg(desc_params, arg_reset);
+    command_line::add_arg(desc_params, arg_rescan);
     command_line::add_arg(desc_params, arg_purge);
     Tools::wallet_rpc_server::init_options(desc_params);
 

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1162,7 +1162,7 @@ simple_wallet::simple_wallet(
     m_consoleHandler.setHandler(
         "rescan",
         boost::bind(&simple_wallet::rescan, this, _1),
-        "Start synchronizing from the scratch"
+        "Reread wallet-related data from blockchain, keeps wallet hisory cache data"
     );
     m_consoleHandler.setHandler(
         "show_seed",
@@ -3252,6 +3252,7 @@ bool simple_wallet::shrink(const std::vector<std::string> &args)
         fail_msg_writer() << "Node is not synchronized. Try to shrink it later.";
         return true;
     }
+
     uint32_t heightThreshold = 0;
     uint64_t mixIn = 0;
     std::string height_str;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -3299,6 +3299,11 @@ bool simple_wallet::shrink(const std::vector<std::string> &args)
         mixIn = 3;
     }
 
+    uint32_t currentHeight = m_node->getLastLocalBlockHeight();
+    if (currentHeight < heightThreshold) {
+        fail_msg_writer() << "Current height is " << currentHeight << ", can't shrink to bigger height";
+        return true;
+    }
     uint32_t currentShrinkHeight = m_wallet->getShrinkHeight();
     if (currentShrinkHeight >= heightThreshold) {
         fail_msg_writer() << "Wallet already shrinked up to " << currentShrinkHeight << " height";

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -144,6 +144,7 @@ private:
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool save(const std::vector<std::string> &args);
     bool reset(const std::vector<std::string> &args);
+    bool purge(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
     bool payment_id(const std::vector<std::string> &args);
     bool change_password(const std::vector<std::string> &args);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -143,7 +143,7 @@ private:
     bool sendMsg(const std::vector<std::string>& args);
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool save(const std::vector<std::string> &args);
-    bool reset(const std::vector<std::string> &args);
+    bool rescan(const std::vector<std::string> &args);
     bool purge(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
     bool payment_id(const std::vector<std::string> &args);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -151,6 +151,7 @@ private:
     bool sweep_dust(const std::vector<std::string> &args);
 	bool estimate_fusion(const std::vector<std::string> &args);
     bool optimize(const std::vector<std::string> &args);
+    bool shrink(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
 	bool get_tx_proof(const std::vector<std::string> &args);
 	bool get_reserve_proof(const std::vector<std::string> &args);

--- a/tests/UnitTests/INodeStubs.h
+++ b/tests/UnitTests/INodeStubs.h
@@ -47,6 +47,7 @@ public:
   virtual uint64_t getLastLocalBlockTimestamp() const override { return 0; }
   virtual uint32_t getNodeHeight() const override { return 0; };
   virtual CryptoNote::BlockHeaderInfo getLastLocalBlockHeaderInfo() const override { return CryptoNote::BlockHeaderInfo(); }
+  virtual uint32_t getGRBHeight() const override { return 0; };
 
   virtual void getNewBlocks(std::vector<Crypto::Hash>&& knownBlockIds, std::vector<CryptoNote::block_complete_entry>& newBlocks, uint32_t& height, const Callback& callback) override { callback(std::error_code()); };
 

--- a/tests/UnitTests/TestWalletLegacy.cpp
+++ b/tests/UnitTests/TestWalletLegacy.cpp
@@ -1551,7 +1551,7 @@ TEST_F(WalletLegacyApi, resetDoesNotChangeAddress) {
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 
   auto expectedAddress = alice->getAddress();
-  alice->reset();
+  alice->purge();
   ASSERT_EQ(expectedAddress, alice->getAddress());
 
   alice->shutdown();
@@ -1564,7 +1564,7 @@ TEST_F(WalletLegacyApi, resetDoesNotChangeAccountKeys) {
   CryptoNote::AccountKeys expectedAccountKeys;
   alice->getAccountKeys(expectedAccountKeys);
 
-  alice->reset();
+  alice->purge();
 
   CryptoNote::AccountKeys actualAccountKeys;
   alice->getAccountKeys(actualAccountKeys);
@@ -1583,7 +1583,7 @@ TEST_F(WalletLegacyApi, resetDoesNotRemoveObservers) {
   WalletSynchronizationProgressUpdatedObserver observer;
   CryptoNote::WalletHelper::IWalletRemoveObserverGuard observerGuard(*alice, observer);
 
-  alice->reset();
+  alice->purge();
   observer.m_current = 0;
 
   aliceNode->updateObservers();
@@ -1602,7 +1602,7 @@ TEST_F(WalletLegacyApi, resetDoesNotChangePassword) {
   alice->initAndGenerate(password);
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 
-  alice->reset();
+  alice->purge();
   ASSERT_TRUE(static_cast<bool>(alice->changePassword(newPassword, password)));
   ASSERT_FALSE(static_cast<bool>(alice->changePassword(password, newPassword)));
 
@@ -1619,7 +1619,7 @@ TEST_F(WalletLegacyApi, resetDoesNotChangePassword) {
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
 //  ASSERT_EQ(TEST_BLOCK_REWARD, alice->pendingBalance());
-//  alice->reset();
+//  alice->purge();
 //  ASSERT_EQ(0, alice->pendingBalance());
 //
 //  alice->shutdown();
@@ -1636,7 +1636,7 @@ TEST_F(WalletLegacyApi, resetDoesNotChangePassword) {
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
 //  ASSERT_EQ(TEST_BLOCK_REWARD, alice->actualBalance());
-//  alice->reset();
+//  alice->purge();
 //  ASSERT_EQ(0, alice->actualBalance());
 //
 //  alice->shutdown();
@@ -1652,7 +1652,7 @@ TEST_F(WalletLegacyApi, resetClearsTransactionHistory) {
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 
   ASSERT_EQ(1, alice->getTransactionCount());
-  alice->reset();
+  alice->purge();
   ASSERT_EQ(0, alice->getTransactionCount());
 
   alice->shutdown();
@@ -1672,7 +1672,7 @@ TEST_F(WalletLegacyApi, resetClearsTransactionHistory) {
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSend(aliceWalletObserver.get()));
 //
 //  ASSERT_EQ(1, alice->getTransferCount());
-//  alice->reset();
+//  alice->purge();
 //  ASSERT_EQ(0, alice->getTransferCount());
 //
 //  alice->shutdown();
@@ -1687,7 +1687,7 @@ TEST_F(WalletLegacyApi, resetClearsTransactionHistory) {
 //  aliceNode->updateObservers();
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
-//  alice->reset();
+//  alice->purge();
 //  aliceNode->updateObservers();
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
@@ -1706,7 +1706,7 @@ TEST_F(WalletLegacyApi, resetClearsTransactionHistory) {
 //  aliceNode->updateObservers();
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
-//  alice->reset();
+//  alice->purge();
 //  aliceNode->updateObservers();
 //  ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 //
@@ -1724,7 +1724,7 @@ TEST_F(WalletLegacyApi, resetAndSyncRestoreTransactions) {
   aliceNode->updateObservers();
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 
-  alice->reset();
+  alice->purge();
   aliceNode->updateObservers();
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 
@@ -1745,7 +1745,7 @@ TEST_F(WalletLegacyApi, resetAndSyncDoNotRestoreTransfers) {
   alice->sendTransaction({ alice->getAddress(), 100 }, m_currency.minimumFee());
   ASSERT_NO_FATAL_FAILURE(WaitWalletSend(aliceWalletObserver.get()));
 
-  alice->reset();
+  alice->purge();
   aliceNode->updateObservers();
   ASSERT_NO_FATAL_FAILURE(WaitWalletSync(aliceWalletObserver.get()));
 


### PR DESCRIPTION
- Change `reset` operation to `rescan` operation which preserves cash data. Also added `purge` operation which is equivalent to the old `reset` operation. 
- `shrink` operation is added. It allows to resend all outputs older than given height to the wallet owner to not have any outputs older then some threshold. It can be used i the future GRB-related functionality.