### PR TITLE
Several fixes for consolidate functionality

### DIFF
--- a/include/ITransfersContainer.h
+++ b/include/ITransfersContainer.h
@@ -124,6 +124,7 @@ public:
     virtual void getUnconfirmedTransactions(std::vector<Crypto::Hash> &transactions) const = 0;
     virtual std::vector<TransactionSpentOutputInformation> getSpentOutputs() const = 0;
     virtual void markTransactionSafe(const Crypto::Hash &transactionHash) = 0;
+    virtual void getSafeTransactions(std::vector<Crypto::Hash> &transactions) const = 0;
 };
 
 } // namespace CryptoNote

--- a/lib/CryptoNoteCore/Core.cpp
+++ b/lib/CryptoNoteCore/Core.cpp
@@ -919,6 +919,13 @@ bool core::handle_block_found(Block &b)
 
     if (bvc.m_verification_failed) {
         logger(ERROR) << "mined block failed verification";
+    } else {
+        if (m_blocksToFind > 0) {
+            m_blocksFound++;
+            if (m_blocksFound >= m_blocksToFind) {
+                get_miner().send_stop_signal();
+            }
+        }
     }
 
     return bvc.m_added_to_main_chain;
@@ -1733,6 +1740,12 @@ bool core::fillTxExtra(const std::vector<uint8_t> &rawExtra, TransactionExtraDet
         }
     }
     return true;
+}
+
+void core::setBlocksToFind(uint64_t blocksToFind)
+{
+    m_blocksFound = 0;
+    m_blocksToFind = blocksToFind;
 }
 
 size_t core::median(std::vector<size_t> &v)

--- a/lib/CryptoNoteCore/Core.h
+++ b/lib/CryptoNoteCore/Core.h
@@ -293,6 +293,8 @@ public:
 
     bool fillTxExtra(const std::vector<uint8_t> &rawExtra, TransactionExtraDetails2 &extraDetails);
 
+    void setBlocksToFind(uint64_t blocksToFind);
+
 private:
     bool add_new_tx(
         const Transaction &tx,
@@ -357,6 +359,9 @@ private:
     std::atomic<bool> m_starter_message_showed;
     Tools::ObserverManager<ICoreObserver> m_observerManager;
     time_t start_time;
+
+    std::atomic<uint64_t> m_blocksFound;
+    std::atomic<uint64_t> m_blocksToFind;
 
     friend class tx_validate_inputs;
 };

--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -684,6 +684,20 @@ difficulty_type Currency::nextDifficulty(uint32_t height,
     std::vector<uint64_t> timestamps,
     std::vector<difficulty_type> cumulativeDifficulties) const
 {
+    // check if we use special scenario with some fixed diff
+    if (CryptoNote::parameters::FIXED_DIFFICULTY > 0)
+    {
+        logger (WARNING) << "Fixed difficulty is used: " <<
+                            CryptoNote::parameters::FIXED_DIFFICULTY;
+        return CryptoNote::parameters::FIXED_DIFFICULTY;
+    }
+    if (m_fixedDifficulty > 0)
+    {
+        logger (WARNING) << "Fixed difficulty is used: " <<
+                            m_fixedDifficulty;
+        return m_fixedDifficulty;
+    }
+
     if (blockMajorVersion >= BLOCK_MAJOR_VERSION_6) {
         return nextDifficultyV6(blockMajorVersion, timestamps, cumulativeDifficulties, height);
     } else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_5) {
@@ -946,20 +960,6 @@ difficulty_type Currency::nextDifficultyV6(uint8_t blockMajorVersion,
 
     // Dynamic difficulty calculation window
     uint32_t diffWindow = timestamps.size() - 1;
-
-    // check if we use special scenario with some fixed diff
-    if (CryptoNote::parameters::FIXED_DIFFICULTY > 0)
-    {
-        logger (WARNING) << "Fixed difficulty is used: " <<
-                            CryptoNote::parameters::FIXED_DIFFICULTY;
-        return CryptoNote::parameters::FIXED_DIFFICULTY;
-    }
-    if (m_fixedDifficulty > 0)
-    {
-        logger (WARNING) << "Fixed difficulty is used: " <<
-                            m_fixedDifficulty;
-        return m_fixedDifficulty;
-    }
 
 
     difficulty_type nextDiffV6 = CryptoNote::parameters::DEFAULT_DIFFICULTY;

--- a/lib/CryptoNoteCore/Miner.cpp
+++ b/lib/CryptoNoteCore/Miner.cpp
@@ -249,8 +249,11 @@ bool miner::start(const AccountPublicAddress &adr, size_t threads_count)
     std::lock_guard<std::mutex> lk(m_threads_lock);
 
     if(!m_threads.empty()) {
-        logger(ERROR) << "Unable to start miner because there are active mining threads";
-        return false;
+        m_stop = true;
+        for (auto &th : m_threads) {
+            th.join();
+        }
+        m_threads.clear();
     }
 
     m_mine_address = adr;

--- a/lib/Transfers/TransfersContainer.cpp
+++ b/lib/Transfers/TransfersContainer.cpp
@@ -602,6 +602,13 @@ void TransfersContainer::markTransactionSafe(const Hash &transactionHash)
     m_safeTxes.insert(transactionHash);
 }
 
+void TransfersContainer::getSafeTransactions(std::vector<Hash> &transactions) const
+{
+    transactions.clear();
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::copy(m_safeTxes.begin(), m_safeTxes.end(), std::back_inserter(transactions));
+}
+
 // pre: m_mutex is locked.
 void TransfersContainer::deleteTransactionTransfers(const Hash& transactionHash)
 {

--- a/lib/Transfers/TransfersContainer.h
+++ b/lib/Transfers/TransfersContainer.h
@@ -190,6 +190,7 @@ public:
     void getUnconfirmedTransactions(std::vector<Crypto::Hash> &transactions) const override;
     std::vector<TransactionSpentOutputInformation> getSpentOutputs() const override;
     void markTransactionSafe(const Crypto::Hash &transactionHash) override;
+    void getSafeTransactions(std::vector<Crypto::Hash> &transactions) const override;
 
     // IStreamSerializable
     void save(std::ostream &os) override;

--- a/lib/Wallet/LegacyKeysImporter.cpp
+++ b/lib/Wallet/LegacyKeysImporter.cpp
@@ -102,7 +102,8 @@ void importLegacyKeys(const std::string &legacyKeysFilename,
     std::string cache;
 
     CryptoNote::WalletLegacySerializer importer(account, transactionsCache);
-    importer.serialize(destination, password, false, cache);
+    std::vector<Crypto::Hash> safeTxes;
+    importer.serialize(destination, password, false, cache, safeTxes);
 }
 
 } // namespace CryptoNote

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -216,9 +216,9 @@ public:
 
     virtual bool isTrackingWallet() = 0;
 
-    virtual void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) = 0;
+    virtual void setConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx) = 0;
     virtual uint32_t getConsolidateHeight() const = 0;
-    virtual TransactionId getConsolidateTx() const = 0;
+    virtual Crypto::Hash getConsolidateTx() const = 0;
 
     virtual void markTransactionSafe(const Crypto::Hash &transactionHash) = 0;
 };

--- a/lib/WalletLegacy/IWalletLegacy.h
+++ b/lib/WalletLegacy/IWalletLegacy.h
@@ -216,8 +216,9 @@ public:
 
     virtual bool isTrackingWallet() = 0;
 
-    virtual void setConsolidateHeight(uint32_t height) = 0;
+    virtual void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) = 0;
     virtual uint32_t getConsolidateHeight() const = 0;
+    virtual TransactionId getConsolidateTx() const = 0;
 
     virtual void markTransactionSafe(const Crypto::Hash &transactionHash) = 0;
 };

--- a/lib/WalletLegacy/WalletLegacy.cpp
+++ b/lib/WalletLegacy/WalletLegacy.cpp
@@ -1200,14 +1200,19 @@ bool WalletLegacy::isTrackingWallet()
     return keys.spendSecretKey == boost::value_initialized<Crypto::SecretKey>();
 }
 
-void WalletLegacy::setConsolidateHeight(uint32_t height)
+void WalletLegacy::setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx)
 {
-    m_transactionsCache.setConsolidateHeight(height);
+    m_transactionsCache.setConsolidateHeight(height, consolidateTx);
 }
 
 uint32_t WalletLegacy::getConsolidateHeight() const
 {
     return m_transactionsCache.getConsolidateHeight();
+}
+
+TransactionId WalletLegacy::getConsolidateTx() const
+{
+    return m_transactionsCache.getConsolidateTx();
 }
 
 void WalletLegacy::markTransactionSafe(const Hash &transactionHash)

--- a/lib/WalletLegacy/WalletLegacy.cpp
+++ b/lib/WalletLegacy/WalletLegacy.cpp
@@ -1200,7 +1200,7 @@ bool WalletLegacy::isTrackingWallet()
     return keys.spendSecretKey == boost::value_initialized<Crypto::SecretKey>();
 }
 
-void WalletLegacy::setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx)
+void WalletLegacy::setConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx)
 {
     m_transactionsCache.setConsolidateHeight(height, consolidateTx);
 }
@@ -1210,7 +1210,7 @@ uint32_t WalletLegacy::getConsolidateHeight() const
     return m_transactionsCache.getConsolidateHeight();
 }
 
-TransactionId WalletLegacy::getConsolidateTx() const
+Hash WalletLegacy::getConsolidateTx() const
 {
     return m_transactionsCache.getConsolidateTx();
 }

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -167,9 +167,9 @@ public:
 
     bool isTrackingWallet() override;
 
-    void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) override;
+    void setConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx) override;
     uint32_t getConsolidateHeight() const override;
-    TransactionId getConsolidateTx() const override;
+    Crypto::Hash getConsolidateTx() const override;
 
     void markTransactionSafe(const Crypto::Hash &transactionHash) override;
 private:

--- a/lib/WalletLegacy/WalletLegacy.h
+++ b/lib/WalletLegacy/WalletLegacy.h
@@ -167,8 +167,9 @@ public:
 
     bool isTrackingWallet() override;
 
-    void setConsolidateHeight(uint32_t height) override;
+    void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) override;
     uint32_t getConsolidateHeight() const override;
+    TransactionId getConsolidateTx() const override;
 
     void markTransactionSafe(const Crypto::Hash &transactionHash) override;
 private:

--- a/lib/WalletLegacy/WalletLegacySerializer.cpp
+++ b/lib/WalletLegacy/WalletLegacySerializer.cpp
@@ -72,6 +72,10 @@ void WalletLegacySerializer::serialize(std::ostream &stream,
         serializer(consolidateHeight, "consolidate_height");
         Crypto::Hash consolidateTx = transactionsCache.getConsolidateTx();
         serializer(consolidateTx, "consolidate_tx_id");
+        consolidateHeight = transactionsCache.getPrevConsolidateHeight();
+        serializer(consolidateHeight, "prev_consolidate_height");
+        consolidateTx = transactionsCache.getPrevConsolidateTx();
+        serializer(consolidateTx, "prev_consolidate_tx_id");
         size_t s = safeTxes.size();
         serializer.beginArray(s, "safe_txes");
         for(auto h: safeTxes)
@@ -188,6 +192,9 @@ void WalletLegacySerializer::deserialize(std::istream &stream,
         Crypto::Hash consolidateTx;
         serializer(consolidateTx, "consolidate_tx_id");
         transactionsCache.setConsolidateHeight(consolidateHeight, consolidateTx);
+        serializer(consolidateHeight, "prev_consolidate_height");
+        serializer(consolidateTx, "prev_consolidate_tx_id");
+        transactionsCache.setPrevConsolidateHeight(consolidateHeight, consolidateTx);
         size_t s = 0;
         serializer.beginArray(s, "safe_txes");
         safeTxes.resize(s);

--- a/lib/WalletLegacy/WalletLegacySerializer.cpp
+++ b/lib/WalletLegacy/WalletLegacySerializer.cpp
@@ -70,7 +70,7 @@ void WalletLegacySerializer::serialize(std::ostream &stream,
     if (walletSerializationVersion >= 3) {
         uint32_t consolidateHeight = transactionsCache.getConsolidateHeight();
         serializer(consolidateHeight, "consolidate_height");
-        TransactionId consolidateTx = transactionsCache.getConsolidateTx();
+        Crypto::Hash consolidateTx = transactionsCache.getConsolidateTx();
         serializer(consolidateTx, "consolidate_tx_id");
         size_t s = safeTxes.size();
         serializer.beginArray(s, "safe_txes");
@@ -185,7 +185,7 @@ void WalletLegacySerializer::deserialize(std::istream &stream,
     if (version >= 3) {
         uint32_t consolidateHeight = 0;
         serializer(consolidateHeight, "consolidate_height");
-        TransactionId consolidateTx;
+        Crypto::Hash consolidateTx;
         serializer(consolidateTx, "consolidate_tx_id");
         transactionsCache.setConsolidateHeight(consolidateHeight, consolidateTx);
         size_t s = 0;

--- a/lib/WalletLegacy/WalletLegacySerializer.cpp
+++ b/lib/WalletLegacy/WalletLegacySerializer.cpp
@@ -70,6 +70,8 @@ void WalletLegacySerializer::serialize(std::ostream &stream,
     if (walletSerializationVersion >= 3) {
         uint32_t consolidateHeight = transactionsCache.getConsolidateHeight();
         serializer(consolidateHeight, "consolidate_height");
+        TransactionId consolidateTx = transactionsCache.getConsolidateTx();
+        serializer(consolidateTx, "consolidate_tx_id");
         size_t s = safeTxes.size();
         serializer.beginArray(s, "safe_txes");
         for(auto h: safeTxes)
@@ -183,7 +185,9 @@ void WalletLegacySerializer::deserialize(std::istream &stream,
     if (version >= 3) {
         uint32_t consolidateHeight = 0;
         serializer(consolidateHeight, "consolidate_height");
-        transactionsCache.setConsolidateHeight(consolidateHeight);
+        TransactionId consolidateTx;
+        serializer(consolidateTx, "consolidate_tx_id");
+        transactionsCache.setConsolidateHeight(consolidateHeight, consolidateTx);
         size_t s = 0;
         serializer.beginArray(s, "safe_txes");
         safeTxes.resize(s);

--- a/lib/WalletLegacy/WalletLegacySerializer.h
+++ b/lib/WalletLegacy/WalletLegacySerializer.h
@@ -47,11 +47,13 @@ public:
         std::ostream &stream,
         const std::string &password,
         bool saveDetailed,
-        const std::string &cache);
+        const std::string &cache,
+        const std::vector<Crypto::Hash> & safeTxes);
     void deserialize(
         std::istream &stream,
         const std::string &password,
-        std::string &cache);
+        std::string &cache,
+        std::vector<Crypto::Hash> & safeTxes);
 
 private:
     void saveKeys(CryptoNote::ISerializer &serializer);

--- a/lib/WalletLegacy/WalletUserTransactionsCache.cpp
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.cpp
@@ -34,7 +34,8 @@ namespace CryptoNote {
 
 WalletUserTransactionsCache::WalletUserTransactionsCache(uint64_t mempoolTxLiveTime)
     : m_unconfirmedTransactions(mempoolTxLiveTime),
-      m_consolidateHeight(0)
+      m_consolidateHeight(0),
+      m_consolidateTx(WALLET_LEGACY_INVALID_TRANSACTION_ID)
 {
 }
 
@@ -48,7 +49,7 @@ bool WalletUserTransactionsCache::serialize(CryptoNote::ISerializer &s)
         updateUnconfirmedTransactions();
         deleteOutdatedTransactions();
         rebuildPaymentsIndex();
-        // m_consolidateHeight is serialized outside this method
+        // m_consolidateHeight and m_consolidateTx is serialized outside this method
     } else {
         UserTransactions txsToSave;
         UserTransfers transfersToSave;
@@ -57,7 +58,7 @@ bool WalletUserTransactionsCache::serialize(CryptoNote::ISerializer &s)
         s(txsToSave, "transactions");
         s(transfersToSave, "transfers");
         s(m_unconfirmedTransactions, "unconfirmed");
-        // m_consolidateHeight is serialized outside this method
+        // m_consolidateHeight and m_consolidateTx is serialized outside this method
     }
 
     return true;
@@ -489,6 +490,10 @@ std::vector<TransactionId> WalletUserTransactionsCache::deleteOutdatedTransactio
     for (auto id: deletedTransactions) {
         assert(id < m_transactions.size());
         m_transactions[id].state = WalletLegacyTransactionState::Deleted;
+        if (id == m_consolidateTx) {
+            m_consolidateTx = WALLET_LEGACY_INVALID_TRANSACTION_ID;
+            m_consolidateTx = 0;
+        }
     }
 
     return deletedTransactions;

--- a/lib/WalletLegacy/WalletUserTransactionsCache.h
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.h
@@ -87,12 +87,12 @@ public:
 
     std::vector<Payments> getTransactionsByPaymentIds(const std::vector<PaymentId>&paymentIds)const;
 
-    void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) {
+    void setConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx) {
         m_consolidateHeight = height;
         m_consolidateTx = consolidateTx;
     }
     uint32_t getConsolidateHeight() const { return m_consolidateHeight; }
-    TransactionId getConsolidateTx() const { return m_consolidateTx; }
+    Crypto::Hash getConsolidateTx() const { return m_consolidateTx; }
 private:
     TransactionId insertTransaction(WalletLegacyTransaction &&Transaction);
     TransferId insertTransfers(const std::vector<WalletLegacyTransfer> &transfers);
@@ -122,7 +122,7 @@ private:
     WalletUnconfirmedTransactions m_unconfirmedTransactions;
     UserPaymentIndex m_paymentsIndex;
     uint32_t m_consolidateHeight;
-    TransactionId m_consolidateTx;
+    Crypto::Hash m_consolidateTx;
 };
 
 } // namespace CryptoNote

--- a/lib/WalletLegacy/WalletUserTransactionsCache.h
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.h
@@ -87,9 +87,12 @@ public:
 
     std::vector<Payments> getTransactionsByPaymentIds(const std::vector<PaymentId>&paymentIds)const;
 
-    void setConsolidateHeight(uint32_t height) { m_consolidateHeight = height; };
-    uint32_t getConsolidateHeight() const { return m_consolidateHeight; };
-
+    void setConsolidateHeight(uint32_t height, const TransactionId &consolidateTx) {
+        m_consolidateHeight = height;
+        m_consolidateTx = consolidateTx;
+    }
+    uint32_t getConsolidateHeight() const { return m_consolidateHeight; }
+    TransactionId getConsolidateTx() const { return m_consolidateTx; }
 private:
     TransactionId insertTransaction(WalletLegacyTransaction &&Transaction);
     TransferId insertTransfers(const std::vector<WalletLegacyTransfer> &transfers);
@@ -119,6 +122,7 @@ private:
     WalletUnconfirmedTransactions m_unconfirmedTransactions;
     UserPaymentIndex m_paymentsIndex;
     uint32_t m_consolidateHeight;
+    TransactionId m_consolidateTx;
 };
 
 } // namespace CryptoNote

--- a/lib/WalletLegacy/WalletUserTransactionsCache.h
+++ b/lib/WalletLegacy/WalletUserTransactionsCache.h
@@ -88,11 +88,29 @@ public:
     std::vector<Payments> getTransactionsByPaymentIds(const std::vector<PaymentId>&paymentIds)const;
 
     void setConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx) {
+        m_prevConsolidateHeight = m_consolidateHeight;
+        m_prevConsolidateTx = m_consolidateTx;
         m_consolidateHeight = height;
         m_consolidateTx = consolidateTx;
     }
+    // used in external serialization
+    void setPrevConsolidateHeight(uint32_t height, const Crypto::Hash &consolidateTx) {
+        m_prevConsolidateHeight = height;
+        m_prevConsolidateTx = consolidateTx;
+    }
     uint32_t getConsolidateHeight() const { return m_consolidateHeight; }
     Crypto::Hash getConsolidateTx() const { return m_consolidateTx; }
+    // used in external serialization
+    uint32_t getPrevConsolidateHeight() const { return m_prevConsolidateHeight; }
+    // used in external serialization
+    Crypto::Hash getPrevConsolidateTx() const { return m_prevConsolidateTx; }
+    void resetConsolidateHeight()
+    {
+        m_consolidateHeight = m_prevConsolidateHeight;
+        m_consolidateTx = m_prevConsolidateTx;
+        m_prevConsolidateHeight = 0;
+        m_prevConsolidateTx = boost::value_initialized<Crypto::Hash>();
+    }
 private:
     TransactionId insertTransaction(WalletLegacyTransaction &&Transaction);
     TransferId insertTransfers(const std::vector<WalletLegacyTransfer> &transfers);
@@ -123,6 +141,8 @@ private:
     UserPaymentIndex m_paymentsIndex;
     uint32_t m_consolidateHeight;
     Crypto::Hash m_consolidateTx;
+    uint32_t m_prevConsolidateHeight;
+    Crypto::Hash m_prevConsolidateTx;
 };
 
 } // namespace CryptoNote

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -90,6 +90,7 @@ private:
     bool ban(const std::vector<std::string> &args);
     bool unban(const std::vector<std::string> &args);
     bool status(const std::vector<std::string> &args);
+    bool generate_blocks(const std::vector<std::string> &args);
 
 private:
     Common::ConsoleHandler m_consoleHandler;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -3367,7 +3367,7 @@ bool simple_wallet::consolidate(const std::vector<std::string> &args)
                 << "Fusion transaction successfully sent, hash: "
                 << Common::podToHex(txInfo.hash);
 
-            m_wallet->setConsolidateHeight(heightThreshold);
+            m_wallet->setConsolidateHeight(heightThreshold, tx);
 
             m_wallet->markTransactionSafe(txInfo.hash);
 

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -3367,7 +3367,7 @@ bool simple_wallet::consolidate(const std::vector<std::string> &args)
                 << "Fusion transaction successfully sent, hash: "
                 << Common::podToHex(txInfo.hash);
 
-            m_wallet->setConsolidateHeight(heightThreshold, tx);
+            m_wallet->setConsolidateHeight(heightThreshold, txInfo.hash);
 
             m_wallet->markTransactionSafe(txInfo.hash);
 

--- a/tests/UnitTests/TestWallet.cpp
+++ b/tests/UnitTests/TestWallet.cpp
@@ -1328,8 +1328,11 @@ void WalletApi::testIWalletDataCompatibility(bool details, const std::string& ca
     iWalletCache.onTransactionUpdated(item.first, item.second);
   }
 
+  std::vector<Crypto::Hash> safeTxes;
+  // TODO: fill tx data for test
+
   std::ofstream stream(BOB_WALLET_PATH, std::ios_base::binary);
-  walletSerializer.serialize(stream, "pass", details, std::string());
+  walletSerializer.serialize(stream, "pass", details, std::string(), safeTxes);
   stream.flush();
   stream.close();
 


### PR DESCRIPTION
Contains:
 - safe txes list persistence (wallet can be reloaded or rescaned, it doesn't interact with curent safe txes)
 - `generate_blocks` daemon api call for easy debug (it is similar to `start_mining` call but generates only guiven blocks number and stops mining)
 - correct processing of the deleted consolidate tx (consolidate height is set to previous value)