### PR TITLE
Add method for improsync

### DIFF
--- a/lib/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/lib/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -128,6 +128,31 @@ struct COMMAND_RPC_GET_TRANSACTIONS
     };
 };
 
+struct COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS
+{
+    struct request
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(startBlock)
+        };
+
+        uint64_t startBlock;
+    };
+
+    struct response
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(status)
+            KV_MEMBER(transactions)
+        }
+
+        std::vector<TransactionDetails2> transactions;
+        std::string status;
+    };
+};
+
 struct COMMAND_RPC_GET_POOL_CHANGES
 {
     struct request
@@ -1312,12 +1337,18 @@ struct difficulty_statistics
         KV_MEMBER(avg_solve_time)
         KV_MEMBER(stddev_solve_time)
         KV_MEMBER(outliers_num)
+        KV_MEMBER(avg_diff)
+        KV_MEMBER(min_diff)
+        KV_MEMBER(max_diff)
     }
 
     uint32_t block_num;
     uint64_t avg_solve_time;
     uint64_t stddev_solve_time;
     uint32_t outliers_num;
+    difficulty_type avg_diff;
+    difficulty_type min_diff;
+    difficulty_type max_diff;
 };
 
 struct COMMAND_RPC_GET_DIFFICULTY_STAT
@@ -1342,7 +1373,14 @@ struct COMMAND_RPC_GET_DIFFICULTY_STAT
             KV_MEMBER(day)
             KV_MEMBER(week)
             KV_MEMBER(month)
+            KV_MEMBER(halfyear)
             KV_MEMBER(year)
+            KV_MEMBER(blocks30)
+            KV_MEMBER(blocks720)
+            KV_MEMBER(blocks5040)
+            KV_MEMBER(blocks21900)
+            KV_MEMBER(blocks131400)
+            KV_MEMBER(blocks262800)
         }
 
         std::string status;
@@ -1350,7 +1388,14 @@ struct COMMAND_RPC_GET_DIFFICULTY_STAT
         difficulty_statistics day;
         difficulty_statistics week;
         difficulty_statistics month;
+        difficulty_statistics halfyear;
         difficulty_statistics year;
+        difficulty_statistics blocks30;
+        difficulty_statistics blocks720;
+        difficulty_statistics blocks5040;
+        difficulty_statistics blocks21900;
+        difficulty_statistics blocks131400;
+        difficulty_statistics blocks262800;
     };
 };
 

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -242,6 +242,15 @@ std::unordered_map<
             false
         }
     },{
+        "/get_transaction_details_by_heights",
+        {
+            jsonMethod<
+                COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS
+                >(
+                        &RpcServer::onGetTransactionsByHeights),
+            false
+        }
+    },{
         "/get_transaction_hashes_by_payment_id",
         {
             jsonMethod<
@@ -388,6 +397,9 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest &request, HttpResponse &
             },{
                 "get_transaction_details_by_hashes",
                 { makeMemberMethod(&RpcServer::onGetTransactionsDetailsByHashes), false }
+            },{
+                "get_transaction_details_by_heights",
+                {makeMemberMethod(&RpcServer::onGetTransactionsByHeights), false}
             },{
                 "k_transaction_details_by_hash",
                 { makeMemberMethod(&RpcServer::onGetTransactionDetailsByHash), false }
@@ -1119,6 +1131,90 @@ bool RpcServer::on_get_transactions(
     }
 
     res.status = CORE_RPC_STATUS_OK;
+
+    return true;
+}
+
+bool RpcServer::onGetTransactionsByHeights(
+        const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::request &req,
+        COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::response &res)
+{
+    try {
+        std::vector<Crypto::Hash> vh;
+
+        size_t additor = 100; // possible to increase
+        for (size_t i = req.startBlock; i <= req.startBlock + additor; i++) {
+            Block blk;
+            uint32_t h = static_cast<uint32_t>(i);
+            Crypto::Hash blockHash = m_core.getBlockIdByHeight(i);
+            if (blockHash == NULL_HASH) {
+                throw JsonRpc::JsonRpcError{
+                        CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT,
+                        std::string("To big height: ")
+                        + std::to_string(h)
+                        + ", current blockchain height = "
+                        + std::to_string(m_core.get_current_blockchain_height())
+                };
+            }
+
+            if (!m_core.getBlockByHash(blockHash, blk)) {
+                throw JsonRpc::JsonRpcError{
+                        CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
+                        "Internal error: can't get block by hash. Hash = " + podToHex(blockHash) + '.'
+                };
+            }
+
+            if (blk.baseTransaction.inputs.front().type() != typeid(BaseInput)) {
+                throw JsonRpc::JsonRpcError{
+                        CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
+                        "Internal error: coinbase transaction in the block has the wrong type"
+                };
+            }
+
+            for (auto tx : blk.transactionHashes) {
+                vh.push_back(tx);
+            }
+        }
+
+        std::vector<TransactionDetails2> transactionDetails;
+        transactionDetails.reserve(vh.size());
+
+        std::list<Crypto::Hash> missedTxs;
+        std::list<Transaction> txs;
+
+        m_core.getTransactions(vh, txs, missedTxs);
+
+        if (!txs.empty()) {
+            for (const Transaction &tx : txs) {
+                TransactionDetails2 txDetails;
+                if (!m_core.fillTransactionDetails(tx, txDetails)) {
+                    throw JsonRpc::JsonRpcError{
+                        CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
+                        "Internal error:  can't fill transaction Details."
+                    };
+                }
+                transactionDetails.push_back(txDetails);
+            }
+
+            res.transactions = std::move(transactionDetails);
+            res.status = CORE_RPC_STATUS_OK;
+        }
+        if (txs.empty() || !missedTxs.empty()) {
+            std::ostringstream oss;
+            std::string seperator;
+            for (auto h : missedTxs) {
+                oss << seperator << Common::podToHex(h);
+                seperator = ",";
+            }
+            res.status = "transaction(s) not found: " + oss.str() + ".";
+        }
+    } catch (std::system_error &e) {
+        res.status = e.what();
+        return false;
+    } catch (std::exception &e) {
+        res.status = "Error: " + std::string(e.what());
+        return false;
+    }
 
     return true;
 }
@@ -2585,36 +2681,128 @@ bool RpcServer::on_get_difficulty_stat(const COMMAND_RPC_GET_DIFFICULTY_STAT::re
                                        res.hour.block_num,
                                        res.hour.avg_solve_time,
                                        res.hour.stddev_solve_time,
-                                       res.hour.outliers_num))
+                                       res.hour.outliers_num,
+                                       res.hour.avg_diff,
+                                       res.hour.min_diff,
+                                       res.hour.max_diff))
             throw std::runtime_error("Failed to get hour difficulty statistics");
         if(!m_core.get_difficulty_stat(req.height,
                                        IMinerHandler::stat_period::day,
                                        res.day.block_num,
                                        res.day.avg_solve_time,
                                        res.day.stddev_solve_time,
-                                       res.day.outliers_num))
+                                       res.day.outliers_num,
+                                       res.day.avg_diff,
+                                       res.day.min_diff,
+                                       res.day.max_diff))
             throw std::runtime_error("Failed to get day difficulty statistics");
         if(!m_core.get_difficulty_stat(req.height,
                                        IMinerHandler::stat_period::week,
                                        res.week.block_num,
                                        res.week.avg_solve_time,
                                        res.week.stddev_solve_time,
-                                       res.week.outliers_num))
+                                       res.week.outliers_num,
+                                       res.week.avg_diff,
+                                       res.week.min_diff,
+                                       res.week.max_diff))
             throw std::runtime_error("Failed to get week difficulty statistics");
         if(!m_core.get_difficulty_stat(req.height,
                                        IMinerHandler::stat_period::month,
                                        res.month.block_num,
                                        res.month.avg_solve_time,
                                        res.month.stddev_solve_time,
-                                       res.month.outliers_num))
+                                       res.month.outliers_num,
+                                       res.month.avg_diff,
+                                       res.month.min_diff,
+                                       res.month.max_diff))
             throw std::runtime_error("Failed to get month difficulty statistics");
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::halfyear,
+                                       res.halfyear.block_num,
+                                       res.halfyear.avg_solve_time,
+                                       res.halfyear.stddev_solve_time,
+                                       res.halfyear.outliers_num,
+                                       res.halfyear.avg_diff,
+                                       res.halfyear.min_diff,
+                                       res.halfyear.max_diff))
+            throw std::runtime_error("Failed to get halfyear difficulty statistics");
         if(!m_core.get_difficulty_stat(req.height,
                                        IMinerHandler::stat_period::year,
                                        res.year.block_num,
                                        res.year.avg_solve_time,
                                        res.year.stddev_solve_time,
-                                       res.year.outliers_num))
-            throw std::runtime_error("Failed to get month difficulty statistics");
+                                       res.year.outliers_num,
+                                       res.year.avg_diff,
+                                       res.year.min_diff,
+                                       res.year.max_diff))
+            throw std::runtime_error("Failed to get year difficulty statistics");
+
+        res.blocks30.block_num = 30;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks30.block_num,
+                                       res.blocks30.avg_solve_time,
+                                       res.blocks30.stddev_solve_time,
+                                       res.blocks30.outliers_num,
+                                       res.blocks30.avg_diff,
+                                       res.blocks30.min_diff,
+                                       res.blocks30.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 30 blocks");
+        res.blocks720.block_num = 720;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks720.block_num,
+                                       res.blocks720.avg_solve_time,
+                                       res.blocks720.stddev_solve_time,
+                                       res.blocks720.outliers_num,
+                                       res.blocks720.avg_diff,
+                                       res.blocks720.min_diff,
+                                       res.blocks720.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 720 blocks");
+        res.blocks5040.block_num = 5040;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks5040.block_num,
+                                       res.blocks5040.avg_solve_time,
+                                       res.blocks5040.stddev_solve_time,
+                                       res.blocks5040.outliers_num,
+                                       res.blocks5040.avg_diff,
+                                       res.blocks5040.min_diff,
+                                       res.blocks5040.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 5040 blocks");
+        res.blocks21900.block_num = 21900;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks21900.block_num,
+                                       res.blocks21900.avg_solve_time,
+                                       res.blocks21900.stddev_solve_time,
+                                       res.blocks21900.outliers_num,
+                                       res.blocks21900.avg_diff,
+                                       res.blocks21900.min_diff,
+                                       res.blocks21900.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 21900 blocks");
+        res.blocks131400.block_num = 131400;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks131400.block_num,
+                                       res.blocks131400.avg_solve_time,
+                                       res.blocks131400.stddev_solve_time,
+                                       res.blocks131400.outliers_num,
+                                       res.blocks131400.avg_diff,
+                                       res.blocks131400.min_diff,
+                                       res.blocks131400.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 131400 blocks");
+        res.blocks262800.block_num = 262800;
+        if(!m_core.get_difficulty_stat(req.height,
+                                       IMinerHandler::stat_period::by_block_number,
+                                       res.blocks262800.block_num,
+                                       res.blocks262800.avg_solve_time,
+                                       res.blocks262800.stddev_solve_time,
+                                       res.blocks262800.outliers_num,
+                                       res.blocks262800.avg_diff,
+                                       res.blocks262800.min_diff,
+                                       res.blocks262800.max_diff))
+            throw std::runtime_error("Failed to get difficulty statistics for 262800 blocks");
     } catch (std::system_error &e) {
         res.status = e.what();
         return false;

--- a/lib/Rpc/RpcServer.h
+++ b/lib/Rpc/RpcServer.h
@@ -112,6 +112,9 @@ private:
     bool on_get_transactions(
         const COMMAND_RPC_GET_TRANSACTIONS::request &req,
         COMMAND_RPC_GET_TRANSACTIONS::response &res);
+    bool onGetTransactionsByHeights(
+            const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::request &req,
+            COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::response &res);
     bool on_send_raw_tx(
         const COMMAND_RPC_SEND_RAW_TX::request &req,
         COMMAND_RPC_SEND_RAW_TX::response &res);


### PR DESCRIPTION
This adds a method to improve the sync for mobile and webwallet
It can be used to gather all transactions from startBlock + 50.