### PR TITLE
Add method for improsync

### DIFF
--- a/lib/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/lib/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -128,6 +128,31 @@ struct COMMAND_RPC_GET_TRANSACTIONS
     };
 };
 
+struct COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS
+{
+    struct request
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(startBlock)
+        };
+
+        uint64_t startBlock;
+    };
+
+    struct response
+    {
+        void serialize(ISerializer &s)
+        {
+            KV_MEMBER(status)
+            KV_MEMBER(transactions)
+        }
+
+        std::vector<TransactionDetails2> transactions;
+        std::string status;
+    };
+};
+
 struct COMMAND_RPC_GET_POOL_CHANGES
 {
     struct request

--- a/lib/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/lib/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -135,9 +135,13 @@ struct COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS
         void serialize(ISerializer &s)
         {
             KV_MEMBER(startBlock)
+            KV_MEMBER(additor)
+            KV_MEMBER(sigCut)
         };
 
-        uint64_t startBlock;
+        uint32_t startBlock;
+        uint32_t additor = 100;
+        bool sigCut;
     };
 
     struct response

--- a/lib/Rpc/RpcServer.cpp
+++ b/lib/Rpc/RpcServer.cpp
@@ -1142,20 +1142,12 @@ bool RpcServer::onGetTransactionsByHeights(
     try {
         std::vector<Crypto::Hash> vh;
 
-        size_t additor = 100; // possible to increase
-        for (size_t i = req.startBlock; i <= req.startBlock + additor; i++) {
+        uint32_t upperBorder = std::min(req.startBlock + req.additor,
+                                        m_core.get_current_blockchain_height());
+        for (size_t i = req.startBlock; i <= upperBorder; i++) {
             Block blk;
             uint32_t h = static_cast<uint32_t>(i);
             Crypto::Hash blockHash = m_core.getBlockIdByHeight(i);
-            if (blockHash == NULL_HASH) {
-                throw JsonRpc::JsonRpcError{
-                        CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT,
-                        std::string("To big height: ")
-                        + std::to_string(h)
-                        + ", current blockchain height = "
-                        + std::to_string(m_core.get_current_blockchain_height())
-                };
-            }
 
             if (!m_core.getBlockByHash(blockHash, blk)) {
                 throw JsonRpc::JsonRpcError{
@@ -1192,6 +1184,9 @@ bool RpcServer::onGetTransactionsByHeights(
                         CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
                         "Internal error:  can't fill transaction Details."
                     };
+                }
+                if (req.sigCut) {
+                    txDetails.signatures.clear();
                 }
                 transactionDetails.push_back(txDetails);
             }

--- a/lib/Rpc/RpcServer.h
+++ b/lib/Rpc/RpcServer.h
@@ -112,6 +112,9 @@ private:
     bool on_get_transactions(
         const COMMAND_RPC_GET_TRANSACTIONS::request &req,
         COMMAND_RPC_GET_TRANSACTIONS::response &res);
+    bool onGetTransactionsByHeights(
+            const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::request &req,
+            COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHTS::response &res);
     bool on_send_raw_tx(
         const COMMAND_RPC_SEND_RAW_TX::request &req,
         COMMAND_RPC_SEND_RAW_TX::response &res);


### PR DESCRIPTION
This adds a method to improve the sync for mobile and webwallet
It can be used to gather all transactions from startBlock + 50.

Now rebased 