### PR TITLE
Fixes: "uint8_t does not name a type" and "std::runtime_error is not …

### DIFF
--- a/lib/Platform/Linux/System/Dispatcher.h
+++ b/lib/Platform/Linux/System/Dispatcher.h
@@ -22,6 +22,8 @@
 #include <functional>
 #include <queue>
 #include <stack>
+#include <stdexcept>
+#include <stdint.h>
 
 #ifndef __GLIBC__
 #include <bits/reg.h>


### PR DESCRIPTION
…a member of std" build errors